### PR TITLE
Update workflows and references to v0.0.5

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -43,6 +43,9 @@ jobs:
       Docker Release for ${{ inputs.image }} @
       ${{ github.event_name == 'pull_request' && format('PR #{0}', github.event.pull_request.number) || github.ref_name }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/rust-build-n-test.yml
+++ b/.github/workflows/rust-build-n-test.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup | Rust | ${{ inputs.toolchain }}
-        uses: mbround18/gh-reusable/actions/setup-rust@main
+        uses: mbround18/gh-reusable/actions/setup-rust@v0.0.5
         with:
           toolchain: ${{ inputs.toolchain }}
           components: ${{ inputs.components }}

--- a/.github/workflows/test-docker-release.yaml
+++ b/.github/workflows/test-docker-release.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify Repo is mbround18/gh-reusable
-        uses: mbround18/gh-reusable/actions/ensure-repository@main
+        uses: mbround18/gh-reusable/actions/ensure-repository@v0.0.5
 
   call_docker_release:
     name: Call Docker Release Workflow

--- a/.github/workflows/test-install-cli.yaml
+++ b/.github/workflows/test-install-cli.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify Repo is mbround18/gh-reusable
-        uses: mbround18/gh-reusable/actions/ensure-repository@main
+        uses: mbround18/gh-reusable/actions/ensure-repository@v0.0.5
 
   test:
     name: "Test CLI Install | ${{ matrix.config.repository }}@${{ matrix.config.version || 'latest' }}"

--- a/.github/workflows/test-rust-build-n-test.yml
+++ b/.github/workflows/test-rust-build-n-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify Repo is mbround18/gh-reusable
-        uses: mbround18/gh-reusable/actions/ensure-repository@main
+        uses: mbround18/gh-reusable/actions/ensure-repository@v0.0.5
   call_build_and_test_workflow:
     name: Call Rust Build and Test Workflow
     uses: ./.github/workflows/rust-build-n-test.yml

--- a/.github/workflows/test-semver.yaml
+++ b/.github/workflows/test-semver.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify Repo is mbround18/gh-reusable
-        uses: mbround18/gh-reusable/actions/ensure-repository@main
+        uses: mbround18/gh-reusable/actions/ensure-repository@v0.0.5
 
   call_semver_action:
     name: Call Semver Action

--- a/.github/workflows/test-setup-rust.yaml
+++ b/.github/workflows/test-setup-rust.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify Repo is mbround18/gh-reusable
-        uses: mbround18/gh-reusable/actions/ensure-repository@main
+        uses: mbround18/gh-reusable/actions/ensure-repository@v0.0.5
   test-base:
     name: "Setup Rust | Base"
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ To use any of the actions provided:
    ```yaml
    steps:
      - name: Use Reusable Action
-       uses: mbround18/gh-reusable/actions/<action-name>@v0.0.4
+       uses: mbround18/gh-reusable/actions/<action-name>@v0.0.5
        with:
          # action inputs
    ```
 
-   Replace `<action-name>` with the name of the action and `v0.0.4` with the tag or commit SHA you wish to use.
+   Replace `<action-name>` with the name of the action and `v0.0.5` with the tag or commit SHA you wish to use.
 
 ### Using Reusable Workflows
 
@@ -48,12 +48,12 @@ To include a reusable workflow:
    ```yaml
    jobs:
      my_job:
-       uses: mbround18/gh-reusable/.github/workflows/<workflow-name>.yaml@v0.0.4
+       uses: mbround18/gh-reusable/.github/workflows/<workflow-name>.yaml@v0.0.5
        with:
          # workflow inputs
    ```
 
-   Replace `<workflow-name>` with the workflow's filename (excluding any `test-` prefixed workflows) and `v0.0.4` with the desired tag or commit SHA.
+   Replace `<workflow-name>` with the workflow's filename (excluding any `test-` prefixed workflows) and `v0.0.5` with the desired tag or commit SHA.
 
 ## Docker Release Workflow
 
@@ -66,7 +66,7 @@ To use the Docker Release Workflow, reference it in your workflow file:
 ```yaml
 jobs:
   docker-release:
-    uses: mbround18/gh-reusable/.github/workflows/docker-release.yaml@v0.0.4
+    uses: mbround18/gh-reusable/.github/workflows/docker-release.yaml@v0.0.5
     with:
       image: "mbround18/example"
       canary_label: "canary"
@@ -108,7 +108,7 @@ To use the Rust Build and Test Workflow, reference it in your workflow file:
 ```yaml
 jobs:
   rust-build-and-test:
-    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yml@v0.0.4
+    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yml@v0.0.5
     with:
       toolchain: "stable"
       components: "clippy,rustfmt"
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify Repo is mbround18/gh-reusable
-        uses: mbround18/gh-reusable/actions/ensure-repository@v0.0.4
+        uses: mbround18/gh-reusable/actions/ensure-repository@v0.0.5
 ```
 
 ### Inputs
@@ -163,7 +163,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install CLI
-        uses: mbround18/gh-reusable/actions/install-cli@v0.0.4
+        uses: mbround18/gh-reusable/actions/install-cli@v0.0.5
         with:
           repository: "owner/repo" # e.g., trunk-rs/trunk
           version: "latest" # Optional: specify version or use 'latest'
@@ -198,7 +198,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Increment version
-        uses: mbround18/gh-reusable/actions/semver@v0.0.4
+        uses: mbround18/gh-reusable/actions/semver@v0.0.5
         with:
           base: "" # Optional: specify base version or leave empty to use the last tag
           increment: "patch" # Optional: specify increment (major, minor, patch)
@@ -234,7 +234,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust
-        uses: mbround18/gh-reusable/actions/setup-rust@v0.0.4
+        uses: mbround18/gh-reusable/actions/setup-rust@v0.0.5
         with:
           toolchain: "stable"
           components: "clippy,rustfmt"

--- a/actions/ensure-repository/README.md
+++ b/actions/ensure-repository/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify Repo is mbround18/gh-reusable
-        uses: mbround18/gh-reusable/actions/ensure-repository@main
+        uses: mbround18/gh-reusable/actions/ensure-repository@v0.0.5
 ```
 
 ## Inputs

--- a/actions/install-cli/README.md
+++ b/actions/install-cli/README.md
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install CLI
-        uses: mbround18/gh-reusable/actions/install-cli@v1
+        uses: mbround18/gh-reusable/actions/install-cli@v0.0.5
         with:
           repository: "owner/repo" # e.g., trunk-rs/trunk
           version: "latest" # Optional: specify version or use 'latest'
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install trunk CLI
-        uses: mbround18/gh-reusable/actions/install-cli@v1
+        uses: mbround18/gh-reusable/actions/install-cli@v0.0.5
         with:
           repository: "trunk-rs/trunk"
           version: "v0.13.0"

--- a/actions/semver/README.md
+++ b/actions/semver/README.md
@@ -16,7 +16,7 @@ jobs:
 
       - name: Increment version
         id: semver
-        uses: mbround18/gh-reusable/actions/semver@v1
+        uses: mbround18/gh-reusable/actions/semver@v0.0.5
         with:
           base: "" # Optional: specify base version or leave empty to use the last tag
           increment: "patch" # Optional: specify increment (major, minor, patch)

--- a/actions/setup-rust/README.md
+++ b/actions/setup-rust/README.md
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Rust
-        uses: mbround18/gh-reusable/actions/setup-rust@v1
+        uses: mbround18/gh-reusable/actions/setup-rust@v0.0.5
         with:
           toolchain: "stable"
           components: "clippy,rustfmt"


### PR DESCRIPTION
Add concurrency locking to workflows and update version references to v0.0.5.

* **Concurrency Locking:**
  - Add concurrency group and cancel-in-progress settings to the `release` job in `.github/workflows/docker-release.yaml`.

* **Version Updates:**
  - Update `uses` reference for `mbround18/gh-reusable/actions/setup-rust` to `v0.0.5` in `.github/workflows/rust-build-n-test.yml`.
  - Update `uses` reference for `mbround18/gh-reusable/actions/ensure-repository` to `v0.0.5` in `.github/workflows/test-docker-release.yaml`, `.github/workflows/test-install-cli.yaml`, `.github/workflows/test-rust-build-n-test.yml`, `.github/workflows/test-semver.yaml`, and `.github/workflows/test-setup-rust.yaml`.
  - Update all references to `v0.0.4` to `v0.0.5` in `README.md`.
  - Update `uses` reference to `v0.0.5` in `actions/ensure-repository/README.md`, `actions/install-cli/README.md`, `actions/semver/README.md`, and `actions/setup-rust/README.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mbround18/gh-reusable/pull/24?shareId=7d805768-24d7-48d0-a2d4-cab467810c9d).