### PR TITLE
feat(ci): implement reusable Rust pipeline for build/test/publish/docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,6 @@ cargo test --verbose
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at `specs/001-enforce-dagger-compliance/plan.md`.
+at `specs/002-reusable-rust-pipeline/plan.md`.
 
 <!-- SPECKIT END -->

--- a/.github/workflows/rust-build-n-test.yaml
+++ b/.github/workflows/rust-build-n-test.yaml
@@ -28,8 +28,35 @@ on:
         type: string
         description: "GitHub runner to use for this workflow."
         default: "ubuntu-latest"
+      publish:
+        required: false
+        type: boolean
+        description: "Whether to publish the crate after a successful build/test run."
+        default: false
+      registry:
+        required: false
+        type: string
+        description: "Cargo registry to publish to when publish=true."
+        default: "crates.io"
+      version:
+        required: false
+        type: string
+        description: "Optional publish version override."
+        default: ""
+      publish_docs:
+        required: false
+        type: boolean
+        description: "Whether to generate Rust docs and publish them to GitHub Pages."
+        default: false
+      docs_path:
+        required: false
+        type: string
+        description: "Path to generated docs for GitHub Pages upload."
+        default: "target/doc"
     secrets:
       DAGGER_CLOUD_TOKEN:
+        required: false
+      CARGO_REGISTRY_TOKEN:
         required: false
 
 concurrency:
@@ -42,30 +69,38 @@ permissions:
 jobs:
   rust-build-and-test:
     name: "Pipeline | Rust Build & Test"
+    permissions:
+      contents: read
     runs-on: ${{ inputs.runs-on }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # de0fac2, https://github.com/actions/checkout/releases/latest
-      - id: dagger
+      - id: pipeline
         uses: mbround18/gh-reusable/.github/actions/dagger-run@main
         with:
           call: >-
-            rust-build-and-test
+            rust-pipeline
             --source=.
             --toolchain=${{ inputs.toolchain }}
             --components=${{ inputs.components }}
             --target=${{ inputs.target }}
             --name=${{ inputs.name }}
+            --publish=${{ inputs.publish }}
+            --token=${{ secrets.CARGO_REGISTRY_TOKEN }}
+            --registry=${{ inputs.registry }}
+            --version=${{ inputs.version }}
+            --publish-docs=false
           module: github.com/mbround18/gh-reusable/packages/dagger-module@main
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
       - if: always()
         uses: actions/github-script@v7
         env:
-          REPORT_JSON: ${{ steps.dagger.outputs.stdout }}
+          REPORT_JSON: ${{ steps.pipeline.outputs.stdout }}
         with:
           script: |
             const fs = require('node:fs')
             const raw = process.env.REPORT_JSON || '{}'
             let report = {}
+
             try {
               report = JSON.parse(raw)
             } catch (error) {
@@ -82,3 +117,25 @@ jobs:
               core.setFailed('Pipeline report indicates failure')
             }
             await core.summary.addRaw(markdown).write()
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-pipeline-report
+          path: |
+            report.json
+            report.md
+
+  publish-docs:
+    name: "Pipeline | Rust Docs to GitHub Pages"
+    if: inputs.publish_docs
+    needs: rust-build-and-test
+    uses: ./.github/workflows/rust-docs-publish.yaml
+    with:
+      toolchain: ${{ inputs.toolchain }}
+      components: ${{ inputs.components }}
+      target: ${{ inputs.target }}
+      docs_path: ${{ inputs.docs_path }}
+      runs-on: ${{ inputs.runs-on }}
+    secrets:
+      DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/rust-docs-publish.yaml
+++ b/.github/workflows/rust-docs-publish.yaml
@@ -1,0 +1,119 @@
+name: "Pipeline | Rust Docs Publish"
+
+on:
+  workflow_call:
+    inputs:
+      toolchain:
+        required: false
+        type: string
+        description: "Rust toolchain to use (for example 1.95, nightly, beta)."
+        default: "1.95"
+      components:
+        required: false
+        type: string
+        description: "Comma-separated list of Rust components to install."
+        default: "clippy,rustfmt"
+      target:
+        required: false
+        type: string
+        description: "Comma-separated list of additional Rust compilation targets."
+        default: ""
+      docs_path:
+        required: false
+        type: string
+        description: "Path to generated Rust docs for GitHub Pages upload."
+        default: "target/doc"
+      runs-on:
+        required: false
+        type: string
+        description: "GitHub runner to use for this workflow."
+        default: "ubuntu-latest"
+    secrets:
+      DAGGER_CLOUD_TOKEN:
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.workflow_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish-docs:
+    name: "Pipeline | Rust Docs to GitHub Pages"
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # de0fac2, https://github.com/actions/checkout/releases/latest
+      - id: docs-check
+        uses: mbround18/gh-reusable/.github/actions/dagger-run@main
+        with:
+          call: >-
+            rust-docs-build
+            --source=.
+            --toolchain=${{ inputs.toolchain }}
+            --components=${{ inputs.components }}
+            --target=${{ inputs.target }}
+            --docs-path=${{ inputs.docs_path }}
+          module: github.com/mbround18/gh-reusable/packages/dagger-module@main
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install "${{ inputs.toolchain }}" --profile minimal
+          rustup default "${{ inputs.toolchain }}"
+      - name: Build rustdoc site
+        shell: bash
+        run: cargo doc --no-deps
+      - name: Validate docs output
+        shell: bash
+        run: |
+          if [ ! -d "${{ inputs.docs_path }}" ]; then
+            echo "Rust docs path '${{ inputs.docs_path }}' does not exist. Ensure cargo doc output path is correct." >&2
+            exit 1
+          fi
+      - if: always()
+        uses: actions/github-script@v7
+        env:
+          REPORT_JSON: ${{ steps.docs-check.outputs.stdout }}
+        with:
+          script: |
+            const fs = require('node:fs')
+            const raw = process.env.REPORT_JSON || '{}'
+            let report = {}
+            try {
+              report = JSON.parse(raw)
+            } catch (error) {
+              core.warning(`Unable to parse Rust docs pipeline report: ${error.message}`)
+            }
+            const payload = report.report || report
+            const markdown = report.reportMarkdown || report.markdown || payload.markdown || '_No docs summary produced._'
+            fs.writeFileSync('rust-docs-report.json', JSON.stringify(payload, null, 2))
+            fs.writeFileSync('rust-docs-report.md', markdown)
+            const hasErrors = (payload.errors || report.errors || []).length > 0
+            const failed = payload.success === false || report.success === false || hasErrors
+            if (failed) {
+              core.setFailed('Rust docs report indicates failure')
+            }
+            await core.summary.addRaw(markdown).write()
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ inputs.docs_path }}
+      - id: deploy
+        name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-docs-pipeline-report
+          path: |
+            rust-docs-report.json
+            rust-docs-report.md

--- a/.github/workflows/test-rust-build-n-test.yaml
+++ b/.github/workflows/test-rust-build-n-test.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - "actions/setup-rust/**"
       - ".github/workflows/rust-build-n-test.yaml"
+      - ".github/workflows/rust-docs-publish.yaml"
       - ".github/workflows/test-rust-build-n-test.yaml"
       - "**/*.rs"
       - "**/*.toml"
@@ -19,6 +20,7 @@ on:
     paths:
       - "actions/setup-rust/**"
       - ".github/workflows/rust-build-n-test.yaml"
+      - ".github/workflows/rust-docs-publish.yaml"
       - ".github/workflows/test-rust-build-n-test.yaml"
       - "**/*.rs"
       - "**/*.toml"
@@ -30,50 +32,25 @@ concurrency:
 
 jobs:
   parity-rust-build-and-test:
-    name: "Parity | Rust Build & Test (Dagger)"
+    name: "Parity | Rust Build & Test reusable workflow"
+    uses: ./.github/workflows/rust-build-n-test.yaml
+    with:
+      toolchain: "1.95"
+      components: "clippy,rustfmt"
+      publish: false
+      publish_docs: false
+    secrets:
+      DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+  parity-rust-docs-contract:
+    name: "Parity | Rust docs contract wiring"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # de0fac2, https://github.com/actions/checkout/releases/latest
-
-      - name: Run Dagger workflow parity
-        id: dagger
-        uses: ./.github/actions/dagger-run
-        with:
-          module: ./packages/dagger-module
-          call: rust-build-and-test --source=. --toolchain=1.95 --components=clippy,rustfmt
-          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-
-      - if: always()
-        uses: actions/github-script@v7
-        env:
-          REPORT_JSON: ${{ steps.dagger.outputs.stdout }}
-        with:
-          script: |
-            const fs = require('node:fs')
-            const raw = process.env.REPORT_JSON || '{}'
-            let report = {}
-            try {
-              report = JSON.parse(raw)
-            } catch (error) {
-              core.warning(`Unable to parse Rust pipeline report: ${error.message}`)
-            }
-
-            const payload = report.report || report
-            const markdown = report.reportMarkdown || report.markdown || payload.markdown || '_No summary produced._'
-            fs.writeFileSync('report.json', JSON.stringify(payload, null, 2))
-            fs.writeFileSync('report.md', markdown)
-            const hasErrors = (payload.errors || report.errors || []).length > 0
-            const failed = payload.success === false || report.success === false || hasErrors
-            if (failed) {
-              core.setFailed('Pipeline report indicates failure')
-            }
-            await core.summary.addRaw(markdown).write()
-
-      - if: always()
-        uses: ./.github/actions/discord-notify
-        with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          status: ${{ job.status }}
-          workflow: ${{ github.workflow }}
-          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          ref: ${{ github.ref_name }}
+      - name: Verify docs adapter wiring
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -q 'publish_docs' .github/workflows/rust-build-n-test.yaml
+          grep -q '.github/workflows/rust-docs-publish.yaml' .github/workflows/rust-build-n-test.yaml
+          grep -q 'rust-docs-build' .github/workflows/rust-docs-publish.yaml

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-enforce-dagger-compliance"
+  "feature_directory": "specs/002-reusable-rust-pipeline"
 }

--- a/packages/dagger-module/src/index.ts
+++ b/packages/dagger-module/src/index.ts
@@ -29,6 +29,7 @@ import {
 import {
   type PipelineReport,
   PipelineReporter,
+  createRustModeOutcomes,
   shellQuote,
   summarizeText,
 } from "./reporting";
@@ -80,6 +81,7 @@ const DEFAULTS = existsSync(DEFAULTS_PATH)
 const DEFAULT_NODE_VERSION = DEFAULTS.node.version;
 const DEFAULT_NODE_IMAGE = `node:${DEFAULT_NODE_VERSION}-${DEFAULTS.node.debianImageSuffix}`;
 const DEFAULT_RUST_TOOLCHAIN = DEFAULTS.rust.toolchain;
+const DEFAULT_RUST_COMPONENTS = "clippy,rustfmt";
 const DEFAULT_RUST_IMAGE = `rust:${DEFAULT_RUST_TOOLCHAIN}-${DEFAULTS.rust.debianImageSuffix}`;
 const DEFAULT_PYTHON_VERSION = DEFAULTS.python.version;
 const DEFAULT_PYTHON_IMAGE = (pythonVersion: string): string =>
@@ -336,7 +338,7 @@ export class GhReusablePipelines {
   async rustBuildAndTest(
     source: Directory,
     toolchain: string = DEFAULT_RUST_TOOLCHAIN,
-    components: string = "clippy,rustfmt",
+    components: string = DEFAULT_RUST_COMPONENTS,
     target: string = "",
     name: string = "",
   ): Promise<string> {
@@ -498,6 +500,238 @@ export class GhReusablePipelines {
       markdown: report.markdown,
       report,
       reportMarkdown: report.markdown,
+    });
+  }
+
+  @func()
+  async rustDocsBuild(
+    source: Directory,
+    toolchain: string = DEFAULT_RUST_TOOLCHAIN,
+    components: string = DEFAULT_RUST_COMPONENTS,
+    target: string = "",
+    docsPath: string = "target/doc",
+  ): Promise<string> {
+    const reporter = this.createReporter("rust-docs-build", {
+      sourceDir: ".",
+      registryUrls: [],
+      credentials: {},
+    });
+    let container = await this.buildRustContainer(
+      source,
+      toolchain,
+      components,
+      target,
+      "",
+    );
+
+    const docsStep = reporter.startStep("cargo doc", {
+      command: "cargo doc --no-deps",
+    });
+    const docsResult = await this.runCapturedStep(container, "cargo doc", [
+      "cargo",
+      "doc",
+      "--no-deps",
+    ]);
+    reporter.endStep(docsStep, {
+      success: docsResult.exitCode === 0,
+      stdout: docsResult.stdout,
+      stderr: docsResult.stderr,
+      stdoutSummary: summarizeText(docsResult.stdout),
+      stderrSummary: summarizeText(docsResult.stderr),
+      exitCode: docsResult.exitCode,
+    });
+    if (docsResult.exitCode !== 0) {
+      reporter.recordError(
+        "cargo doc",
+        docsResult.stderr || docsResult.stdout,
+        "Fix rustdoc generation failures before publishing docs",
+      );
+      const report = reporter.finalize();
+      return JSON.stringify({
+        success: false,
+        markdown: report.markdown,
+        report,
+        reportMarkdown: report.markdown,
+      });
+    }
+    container = docsResult.container;
+
+    const validateStep = reporter.startStep("validate docs output", {
+      command: `test -d ${docsPath}`,
+    });
+    const docsOutputCheck = await this.runCapturedStep(
+      container,
+      "validate docs output",
+      ["sh", "-lc", `test -d ${shellQuote(docsPath)}`],
+    );
+    reporter.endStep(validateStep, {
+      success: docsOutputCheck.exitCode === 0,
+      stdout: docsOutputCheck.stdout,
+      stderr: docsOutputCheck.stderr,
+      stdoutSummary: summarizeText(docsOutputCheck.stdout),
+      stderrSummary: summarizeText(docsOutputCheck.stderr),
+      exitCode: docsOutputCheck.exitCode,
+    });
+    if (docsOutputCheck.exitCode !== 0) {
+      reporter.recordError(
+        "validate docs output",
+        docsOutputCheck.stderr || docsOutputCheck.stdout,
+        `Rust docs output path "${docsPath}" was not found`,
+      );
+      const report = reporter.finalize();
+      return JSON.stringify({
+        success: false,
+        markdown: report.markdown,
+        report,
+        reportMarkdown: report.markdown,
+      });
+    }
+
+    reporter.setOutput("packageMetadata", {
+      docsPath,
+      command: "cargo doc --no-deps",
+    });
+    const report = reporter.finalize();
+    return JSON.stringify({
+      success: true,
+      markdown: report.markdown,
+      report,
+      reportMarkdown: report.markdown,
+    });
+  }
+
+  @func()
+  async rustPipeline(
+    source: Directory,
+    toolchain: string = DEFAULT_RUST_TOOLCHAIN,
+    components: string = DEFAULT_RUST_COMPONENTS,
+    target: string = "",
+    name: string = "",
+    publish: boolean = false,
+    token: string = "",
+    registry: string = "crates.io",
+    version: string = "",
+    publishDocs: boolean = false,
+    docsPath: string = "target/doc",
+  ): Promise<string> {
+    const reporter = this.createReporter("rust-pipeline", {
+      sourceDir: ".",
+      version,
+      registryUrls: publish ? [registry] : [],
+      credentials: { CARGO_REGISTRY_TOKEN: publish && Boolean(token.trim()) },
+    });
+    const modeOutcomes = createRustModeOutcomes({
+      publishEnabled: publish,
+      docsEnabled: publishDocs,
+    });
+
+    if (publish && !token.trim()) {
+      modeOutcomes.publish.failureReason =
+        "CARGO_REGISTRY_TOKEN is required when publish=true";
+      reporter.recordError(
+        "publish contract validation",
+        modeOutcomes.publish.failureReason,
+        "Provide CARGO_REGISTRY_TOKEN when enabling publish",
+      );
+      reporter.setOutput("rustModeOutcomes", modeOutcomes);
+      const report = reporter.finalize();
+      return JSON.stringify({
+        success: false,
+        report,
+        markdown: report.markdown,
+        reportMarkdown: report.markdown,
+      });
+    }
+
+    const baselineResult = this.parsePipelineResponse(
+      await this.rustBuildAndTest(source, toolchain, components, target, name),
+    );
+    const baselineSuccess = baselineResult.success !== false;
+    if (!baselineSuccess) {
+      reporter.recordError(
+        "rust-build-and-test",
+        "Baseline Rust build/test checks failed",
+        "Fix Rust build/test errors before optional modes run",
+      );
+      modeOutcomes.publish.skippedReason =
+        "baseline build/test checks failed before publish";
+      modeOutcomes.docs.skippedReason =
+        "baseline build/test checks failed before docs";
+      reporter.setOutput("rustModeOutcomes", modeOutcomes);
+      const report = reporter.finalize();
+      return JSON.stringify({
+        success: false,
+        report,
+        markdown: [report.markdown, baselineResult.markdown]
+          .filter(Boolean)
+          .join("\n\n---\n\n"),
+        reportMarkdown: [report.markdown, baselineResult.markdown]
+          .filter(Boolean)
+          .join("\n\n---\n\n"),
+      });
+    }
+
+    let publishResultMarkdown = "";
+    if (publish) {
+      modeOutcomes.publish.attempted = true;
+      const publishResult = this.parsePipelineResponse(
+        await this.publishRustCrate(source, token, version, registry),
+      );
+      modeOutcomes.publish.success = publishResult.success !== false;
+      if (!modeOutcomes.publish.success) {
+        modeOutcomes.publish.failureReason =
+          "publish-rust-crate failed; see step logs for details";
+        reporter.recordError(
+          "publish-rust-crate",
+          modeOutcomes.publish.failureReason,
+          "Check Cargo metadata, versioning, and crates.io credentials",
+        );
+      }
+      publishResultMarkdown = publishResult.markdown;
+    }
+
+    let docsResultMarkdown = "";
+    if (publishDocs) {
+      modeOutcomes.docs.attempted = true;
+      const docsResult = this.parsePipelineResponse(
+        await this.rustDocsBuild(
+          source,
+          toolchain,
+          components,
+          target,
+          docsPath,
+        ),
+      );
+      modeOutcomes.docs.success = docsResult.success !== false;
+      if (!modeOutcomes.docs.success) {
+        modeOutcomes.docs.failureReason =
+          "rust-docs-build failed; ensure docs output is generated";
+        reporter.recordError(
+          "rust-docs-build",
+          modeOutcomes.docs.failureReason,
+          "Fix rustdoc generation before deploying to GitHub Pages",
+        );
+      }
+      docsResultMarkdown = docsResult.markdown;
+    }
+
+    reporter.setOutput("rustModeOutcomes", modeOutcomes);
+    const report = reporter.finalize();
+    const success = report.errors.length === 0;
+    const combinedMarkdown = [
+      report.markdown,
+      baselineResult.markdown,
+      publishResultMarkdown,
+      docsResultMarkdown,
+    ]
+      .filter(Boolean)
+      .join("\n\n---\n\n");
+
+    return JSON.stringify({
+      success,
+      report,
+      markdown: combinedMarkdown,
+      reportMarkdown: combinedMarkdown,
     });
   }
 
@@ -1529,6 +1763,28 @@ export class GhReusablePipelines {
     });
   }
 
+  private parsePipelineResponse(raw: string): {
+    success?: boolean;
+    markdown: string;
+    report?: PipelineReport;
+  } {
+    try {
+      const parsed = JSON.parse(raw) as {
+        success?: boolean;
+        markdown?: string;
+        reportMarkdown?: string;
+        report?: PipelineReport;
+      };
+      return {
+        success: parsed.success,
+        markdown: parsed.reportMarkdown ?? parsed.markdown ?? "",
+        report: parsed.report,
+      };
+    } catch {
+      return { success: false, markdown: "" };
+    }
+  }
+
   private async runCapturedStep(
     container: Container,
     name: string,
@@ -2468,7 +2724,7 @@ export class GhReusablePipelines {
   async setupRust(
     source: Directory,
     toolchain: string = DEFAULT_RUST_TOOLCHAIN,
-    components: string = "clippy,rustfmt",
+    components: string = DEFAULT_RUST_COMPONENTS,
     target: string = "",
     crates: string = "",
   ): Promise<Container> {
@@ -2723,7 +2979,7 @@ export class GhReusablePipelines {
     buildCommand: string = "cargo build --release",
     archiveName: string = "bundle.zip",
     toolchain: string = DEFAULT_RUST_TOOLCHAIN,
-    components: string = "clippy,rustfmt",
+    components: string = DEFAULT_RUST_COMPONENTS,
     repository: string = "",
     discordWebhook: string = "",
   ): Promise<string> {

--- a/packages/dagger-module/src/reporting.ts
+++ b/packages/dagger-module/src/reporting.ts
@@ -1,4 +1,5 @@
 export type PipelineStepStatus = "success" | "failure" | "skipped";
+import type { RustPipelineModeOutcomes } from "./types";
 
 export interface PipelineReportMetadata {
   readonly pipelineName: string;
@@ -49,6 +50,7 @@ export interface PipelineReportOutputs {
   readonly auditSummary?: import("./audit-types").AuditSummary;
   readonly cacheBackend?: string;
   readonly cacheKey?: string;
+  readonly rustModeOutcomes?: RustPipelineModeOutcomes;
 }
 
 export interface PipelineReport {
@@ -348,6 +350,28 @@ export function summarizeText(text: string, limit = 200): string {
 
 export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function createRustModeOutcomes(options: {
+  publishEnabled: boolean;
+  docsEnabled: boolean;
+}): RustPipelineModeOutcomes {
+  return {
+    publish: {
+      mode: "publish",
+      enabled: options.publishEnabled,
+      attempted: false,
+      skippedReason: options.publishEnabled
+        ? undefined
+        : "publish flag disabled",
+    },
+    docs: {
+      mode: "docs",
+      enabled: options.docsEnabled,
+      attempted: false,
+      skippedReason: options.docsEnabled ? undefined : "publish_docs disabled",
+    },
+  };
 }
 
 function truncate(value: string, limit: number): string {

--- a/packages/dagger-module/src/types.ts
+++ b/packages/dagger-module/src/types.ts
@@ -106,6 +106,20 @@ export interface ReporterInputs {
   credentials?: Readonly<Record<string, boolean>>;
 }
 
+export interface RustModeOutcome {
+  mode: "publish" | "docs";
+  enabled: boolean;
+  attempted: boolean;
+  success?: boolean;
+  skippedReason?: string;
+  failureReason?: string;
+}
+
+export interface RustPipelineModeOutcomes {
+  publish: RustModeOutcome;
+  docs: RustModeOutcome;
+}
+
 export interface BranchRule {
   increment: SemverIncrement;
   patterns: RegExp[];

--- a/packages/dagger-pipelines/package.json
+++ b/packages/dagger-pipelines/package.json
@@ -24,7 +24,8 @@
     "test:coverage": "vitest run --coverage",
     "test:compliance:us1": "vitest run -- src/workflow-governance.test.ts src/dagger-module-integration.test.ts src/standards-defaults.test.ts src/security-workflows.test.ts src/audit-workflow.test.ts",
     "test:compliance:us2": "vitest run -- src/release-workflows.test.ts src/publish-workflow.test.ts src/spec-governance-workflow.test.ts",
-    "test:compliance": "pnpm run test:compliance:us1 && pnpm run test:compliance:us2",
+    "test:compliance:us3": "vitest run -- src/rust-workflow.test.ts src/release-workflows.test.ts src/security-workflows.test.ts src/workflow-governance.test.ts src/dagger-module-integration.test.ts",
+    "test:compliance": "pnpm run test:compliance:us1 && pnpm run test:compliance:us2 && pnpm run test:compliance:us3",
     "dagger:ci": "node dist/cli.js ci",
     "dagger:build-and-push": "node dist/cli.js build-and-push",
     "dagger:workflow": "node dist/cli.js workflow"

--- a/packages/dagger-pipelines/src/dagger-module-integration.test.ts
+++ b/packages/dagger-pipelines/src/dagger-module-integration.test.ts
@@ -65,7 +65,9 @@ test("dagger module exposes expected integration entrypoints", () => {
       "publishYarn",
       "pnpmBuildAndTest",
       "pythonBuildAndTest",
+      "rustDocsBuild",
       "rustBuildAndTest",
+      "rustPipeline",
     ]),
   );
   expect(exportedFunctions).not.toContain("detectLanguageFamilies");
@@ -157,7 +159,8 @@ test("all dagger-for-github workflow integrations use module+call and no wrapper
             requireExplicitModule:
               workflowFile === "pnpm-build-n-test.yaml" ||
               workflowFile === "python-build-n-test.yaml" ||
-              workflowFile === "rust-build-n-test.yaml",
+              workflowFile === "rust-build-n-test.yaml" ||
+              workflowFile === "rust-docs-publish.yaml",
           });
 
           inspectedSteps.push(`${workflowFile}:${jobName} (composite)`);

--- a/packages/dagger-pipelines/src/index.ts
+++ b/packages/dagger-pipelines/src/index.ts
@@ -600,7 +600,9 @@ export {
 } from "./semver.js";
 export {
   evaluateDaggerInvocationStep,
+  evaluateConditionalSecretRequirement,
   evaluateWorkflowDefinitionCompliance,
+  hasWorkflowReference,
   parseDaggerCallName,
   type DaggerInvocationStep,
   type WorkflowEnvironment as PipelineWorkflowEnvironment,

--- a/packages/dagger-pipelines/src/publish-workflow.test.ts
+++ b/packages/dagger-pipelines/src/publish-workflow.test.ts
@@ -99,6 +99,11 @@ test("publish workflow wires every publish entrypoint", () => {
   ).toBe(true);
   expect(
     daggerCalls.some(({ step }) =>
+      step.with?.call?.includes("--token=${{ secrets.CARGO_REGISTRY_TOKEN }}"),
+    ),
+  ).toBe(true);
+  expect(
+    daggerCalls.some(({ step }) =>
       step.with?.call?.includes("publish-helm-chart"),
     ),
   ).toBe(true);

--- a/packages/dagger-pipelines/src/release-workflows.test.ts
+++ b/packages/dagger-pipelines/src/release-workflows.test.ts
@@ -13,6 +13,7 @@ type WorkflowJob = {
   uses?: string;
   with?: Record<string, unknown>;
   secrets?: Record<string, unknown>;
+  steps?: Array<{ name?: string; run?: string }>;
 };
 
 function readWorkflow(fileName: string): {
@@ -165,4 +166,29 @@ test("release workflow interfaces remain backward compatible", () => {
       "track_release_summary",
     ]),
   );
+});
+
+test("rust reusable and docs publish workflows preserve compatibility contracts", () => {
+  const rustBuild = readWorkflow("rust-build-n-test.yaml");
+  const rustDocs = readWorkflow("rust-docs-publish.yaml");
+  const buildInputs = rustBuild.on?.workflow_call?.inputs ?? {};
+  const docsInputs = rustDocs.on?.workflow_call?.inputs ?? {};
+
+  expect(buildInputs.publish?.default).toBe(false);
+  expect(buildInputs.registry?.default).toBe("crates.io");
+  expect(buildInputs.version?.default).toBe("");
+  expect(buildInputs.publish_docs?.default).toBe(false);
+  expect(buildInputs.docs_path?.default).toBe("target/doc");
+
+  expect(rustBuild.jobs?.["publish-docs"]?.uses).toContain(
+    ".github/workflows/rust-docs-publish.yaml",
+  );
+  expect(docsInputs.docs_path?.default).toBe("target/doc");
+  expect(
+    String(
+      rustDocs.jobs?.["publish-docs"]?.steps?.find((step) =>
+        step.name?.includes("Validate docs output"),
+      )?.run ?? "",
+    ),
+  ).toContain("Ensure cargo doc output path is correct");
 });

--- a/packages/dagger-pipelines/src/rust-workflow.test.ts
+++ b/packages/dagger-pipelines/src/rust-workflow.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+import { expect, test } from "vitest";
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+const repositoryRoot = path.resolve(dirname, "../../../");
+const workflowPath = path.join(
+  repositoryRoot,
+  ".github",
+  "workflows",
+  "rust-build-n-test.yaml",
+);
+
+type WorkflowStep = {
+  name?: string;
+  id?: string;
+  if?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, string>;
+};
+
+function getWorkflow() {
+  return parse(readFileSync(workflowPath, "utf8")) as {
+    on?: {
+      workflow_call?: {
+        inputs?: Record<
+          string,
+          {
+            type?: string;
+            default?: unknown;
+            required?: boolean;
+          }
+        >;
+        secrets?: Record<string, unknown>;
+      };
+    };
+    jobs?: Record<
+      string,
+      {
+        if?: string;
+        permissions?: Record<string, string>;
+        steps?: WorkflowStep[];
+      }
+    >;
+  };
+}
+
+test("rust reusable workflow exposes publish and docs opt-in inputs", () => {
+  const workflow = getWorkflow();
+  const inputs = workflow.on?.workflow_call?.inputs ?? {};
+
+  expect(inputs.toolchain?.default).toBe("1.95");
+  expect(inputs.publish?.type).toBe("boolean");
+  expect(inputs.publish?.default).toBe(false);
+  expect(inputs.publish_docs?.type).toBe("boolean");
+  expect(inputs.publish_docs?.default).toBe(false);
+  expect(inputs.registry?.default).toBe("crates.io");
+  expect(inputs.docs_path?.default).toBe("target/doc");
+});
+
+test("rust reusable workflow declares conditional publish secret", () => {
+  const workflow = getWorkflow();
+  const secrets = workflow.on?.workflow_call?.secrets ?? {};
+
+  expect(secrets.DAGGER_CLOUD_TOKEN).toBeDefined();
+  expect(secrets.CARGO_REGISTRY_TOKEN).toBeDefined();
+});
+
+test("rust reusable workflow wires baseline, publish gate, and docs deployment", () => {
+  const workflow = getWorkflow();
+  const buildJob = workflow.jobs?.["rust-build-and-test"];
+  const docsJob = workflow.jobs?.["publish-docs"];
+  const steps = buildJob?.steps ?? [];
+
+  expect(
+    steps.some((step) =>
+      step.with?.call?.includes("rust-pipeline --source=."),
+    ),
+  ).toBe(true);
+  expect(
+    steps.some(
+      (step) =>
+        step.with?.call?.includes("--publish=${{ inputs.publish }}") &&
+        step.with?.call?.includes("--token=${{ secrets.CARGO_REGISTRY_TOKEN }}"),
+    ),
+  ).toBe(true);
+
+  expect(docsJob?.if).toBe("inputs.publish_docs");
+  expect(docsJob?.permissions).toBeUndefined();
+  expect(
+    String((docsJob as { uses?: string } | undefined)?.uses ?? "").includes(
+      ".github/workflows/rust-docs-publish.yaml",
+    ),
+  ).toBe(true);
+});
+
+test("rust reusable workflow remains backward compatible for core build-test interface", () => {
+  const workflow = getWorkflow();
+  const inputNames = Object.keys(
+    workflow.on?.workflow_call?.inputs ?? {},
+  ).sort();
+
+  expect(inputNames).toEqual(
+    expect.arrayContaining([
+      "toolchain",
+      "components",
+      "target",
+      "name",
+      "runs-on",
+    ]),
+  );
+});

--- a/packages/dagger-pipelines/src/security-workflows.test.ts
+++ b/packages/dagger-pipelines/src/security-workflows.test.ts
@@ -29,6 +29,7 @@ function readWorkflow(fileName: string): {
       if?: string;
       uses?: string;
       with?: Record<string, unknown>;
+      permissions?: Record<string, string>;
       steps?: WorkflowStep[];
     }
   >;
@@ -101,4 +102,21 @@ test("security workflow composes codeql and dependency review reusables", () => 
   );
   expect(String(dependencyReview?.with?.semgrep_config ?? "")).toBe("auto");
   expect(dependencyReview?.with?.create_alerts).toBe(true);
+});
+
+test("rust workflows keep least-privilege defaults and docs-scoped elevation", () => {
+  const rustBuild = readWorkflow("rust-build-n-test.yaml");
+  const rustDocs = readWorkflow("rust-docs-publish.yaml");
+
+  expect(rustBuild.permissions?.contents).toBe("read");
+  expect(rustBuild.permissions?.pages).toBeUndefined();
+  expect(rustBuild.permissions?.["id-token"]).toBeUndefined();
+  expect(rustBuild.jobs?.["rust-build-and-test"]?.with).toBeUndefined();
+
+  expect(rustDocs.permissions?.contents).toBe("read");
+  expect(rustDocs.jobs?.["publish-docs"]?.permissions?.contents).toBe("read");
+  expect(rustDocs.jobs?.["publish-docs"]?.permissions?.pages).toBe("write");
+  expect(rustDocs.jobs?.["publish-docs"]?.permissions?.["id-token"]).toBe(
+    "write",
+  );
 });

--- a/packages/dagger-pipelines/src/standards-defaults.test.ts
+++ b/packages/dagger-pipelines/src/standards-defaults.test.ts
@@ -83,11 +83,13 @@ test("dockerfiles and workflow defaults align with defaults.json", () => {
   expect(semverDockerfile).toContain(`FROM ${expectedNodeSlim}`);
 
   const rustWorkflow = readText(".github/workflows/rust-build-n-test.yaml");
+  const rustDocsWorkflow = readText(".github/workflows/rust-docs-publish.yaml");
   const rustBinaryRelease = readText(
     ".github/workflows/rust-binary-release.yaml",
   );
   const setupRustAction = readText("actions/setup-rust/action.yml");
   expect(rustWorkflow).toContain(`default: "${defaults.rust.toolchain}"`);
+  expect(rustDocsWorkflow).toContain(`default: "${defaults.rust.toolchain}"`);
   expect(rustBinaryRelease).toContain(`default: "${defaults.rust.toolchain}"`);
   expect(setupRustAction).toContain(`default: "${defaults.rust.toolchain}"`);
 });
@@ -98,6 +100,7 @@ test("legacy runtime literals are banned in standards-critical files", () => {
     "packages/dagger-pipelines/src/index.ts",
     "packages/dagger-pipelines/src/workflows.ts",
     ".github/workflows/rust-build-n-test.yaml",
+    ".github/workflows/rust-docs-publish.yaml",
     ".github/workflows/rust-binary-release.yaml",
     "actions/setup-rust/action.yml",
     "scripts/generate-ci-skill.ts",

--- a/packages/dagger-pipelines/src/workflow-governance.test.ts
+++ b/packages/dagger-pipelines/src/workflow-governance.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
 import { expect, test } from "vitest";
+import { evaluateConditionalSecretRequirement } from "./workflows.js";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -59,4 +60,23 @@ test("workflow inputs and secrets are always referenced", () => {
     expectWorkflowReferences(raw, "input", dispatchInputs, workflowFile);
     expectWorkflowReferences(raw, "secret", secrets, workflowFile);
   }
+});
+
+test("rust workflow enforces conditional publish secret and docs references", () => {
+  const workflowFile = "rust-build-n-test.yaml";
+  const { raw } = readWorkflow(workflowFile);
+  const conditional = evaluateConditionalSecretRequirement({
+    workflowFile,
+    workflowRaw: raw,
+    whenInput: "publish",
+    secret: "CARGO_REGISTRY_TOKEN",
+    conditionSnippet: "inputs.publish",
+  });
+
+  expect(
+    conditional.status,
+    conditional.issues.map((issue) => issue.message).join("; "),
+  ).toBe("pass");
+  expect(raw.includes("inputs.publish_docs")).toBe(true);
+  expect(raw.includes("inputs.docs_path")).toBe(true);
 });

--- a/packages/dagger-pipelines/src/workflows.test.ts
+++ b/packages/dagger-pipelines/src/workflows.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 
 import {
   WORKFLOW_DEFINITIONS,
+  evaluateConditionalSecretRequirement,
   validateWorkflowDefinitions,
 } from "./workflows.js";
 
@@ -90,4 +91,19 @@ test("tier1 workflows use executable parity flows instead of shallow checks", ()
   );
   expect(pnpmParity).toContain("pnpm run build");
   expect(pnpmParity).toContain("pnpm run test");
+});
+
+test("conditional secret helper validates publish contract snippets", () => {
+  const raw = `
+  if: inputs.publish
+  run: echo \${{ secrets.CARGO_REGISTRY_TOKEN }}
+  `;
+  const result = evaluateConditionalSecretRequirement({
+    workflowFile: "rust-build-n-test.yaml",
+    workflowRaw: raw,
+    whenInput: "publish",
+    secret: "CARGO_REGISTRY_TOKEN",
+    conditionSnippet: "inputs.publish",
+  });
+  expect(result.status).toBe("pass");
 });

--- a/packages/dagger-pipelines/src/workflows.ts
+++ b/packages/dagger-pipelines/src/workflows.ts
@@ -1087,6 +1087,50 @@ export function parseDaggerCallName(call: string): string {
   return call.trim().split(/\s+/)[0] ?? "";
 }
 
+export function hasWorkflowReference(
+  workflowRaw: string,
+  kind: "input" | "secret",
+  name: string,
+): boolean {
+  const token = kind === "input" ? `inputs.${name}` : `secrets.${name}`;
+  return workflowRaw.includes(token);
+}
+
+export function evaluateConditionalSecretRequirement(input: {
+  workflowFile: string;
+  workflowRaw: string;
+  whenInput: string;
+  secret: string;
+  conditionSnippet?: string;
+}): ComplianceResult {
+  const issues: ComplianceIssue[] = [];
+  if (!hasWorkflowReference(input.workflowRaw, "input", input.whenInput)) {
+    issues.push({
+      code: "missing-conditional-input-reference",
+      message: `${input.workflowFile} must reference inputs.${input.whenInput}`,
+    });
+  }
+  if (!hasWorkflowReference(input.workflowRaw, "secret", input.secret)) {
+    issues.push({
+      code: "missing-conditional-secret-reference",
+      message: `${input.workflowFile} must reference secrets.${input.secret}`,
+    });
+  }
+  if (
+    input.conditionSnippet &&
+    !input.workflowRaw.includes(input.conditionSnippet)
+  ) {
+    issues.push({
+      code: "missing-conditional-guard",
+      message: `${input.workflowFile} must include conditional guard "${input.conditionSnippet}"`,
+    });
+  }
+  return {
+    status: issues.length === 0 ? "pass" : "fail",
+    issues,
+  };
+}
+
 export function evaluateDaggerInvocationStep(
   step: DaggerInvocationStep,
 ): ComplianceResult {

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   author: mbround18
   dagger-version: "v0.x"
   module: "github.com/mbround18/gh-reusable/packages/dagger-module@main"
-  generated: "2026-06-19"
+  generated: "2026-07-13"
 ---
 
 # gh-reusable CI skill
@@ -46,84 +46,88 @@ skills/ci/
 ## Composite actions
 
 **`.github/actions/dagger-run`** — Warms the Dagger engine and executes a Dagger module function call.  
- Inputs: `call`, `module`, `cloud-token`, `dagger-version`, `engine-version`  
- Outputs: `stdout`
+  Inputs: `call`, `module`, `cloud-token`, `dagger-version`, `engine-version`  
+  Outputs: `stdout`
 
 **`.github/actions/discord-notify`** — Sends a CI status notification to a Discord webhook.  
- Inputs: `webhook-url`, `status`, `workflow`, `run-url`, `ref`
+  Inputs: `webhook-url`, `status`, `workflow`, `run-url`, `ref`
 
 ## Reusable workflows
 
 Full input/secret details in [references/ci-manifest.json](references/ci-manifest.json).
 
-| File                                                      | Name                           | Inputs (? = optional)                                                                                                                                                                                                     | Secrets (? = optional)                                                                                       |
-| --------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------- |
-| [`audit.yaml`](references/ci-manifest.json)               | Audit Workflow                 | runs-on?, semgrep_config?, include_gitleaks?, create_alerts?, track_release_summary?                                                                                                                                      | DAGGER_CLOUD_TOKEN?                                                                                          |
-| [`codeql.yaml`](references/ci-manifest.json)              | Security                       | Dagger Code Scan                                                                                                                                                                                                          | semgrep_config?, include_gitleaks?, create_alerts?, runs-on?                                                 | DAGGER_CLOUD_TOKEN? |
-| [`dependency-review.yaml`](references/ci-manifest.json)   | Security                       | Dagger Dependency Audit                                                                                                                                                                                                   | runs-on?, semgrep_config?, create_alerts?                                                                    | DAGGER_CLOUD_TOKEN? |
-| [`docker-release.yaml`](references/ci-manifest.json)      | Docker Release Workflow        | image, context?, canary_label?, dockerfile?, ghcr?, ghcr_username?, dockerhub_username?, semver_prefix?, prepend_target?, target?, platforms?, download_artifact?, download_artifact_destination?, track_release_summary? | DOCKER_TOKEN, GHCR_TOKEN?, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL?                                         |
-| [`enforce-labels.yaml`](references/ci-manifest.json)      | Enforce PR Labels              | required_labels_any?, required_labels_any_description?, banned_labels?, runs-on?                                                                                                                                          | DAGGER_CLOUD_TOKEN?                                                                                          |
-| [`pnpm-build-n-test.yaml`](references/ci-manifest.json)   | Pipeline                       | pnpm Build & Test                                                                                                                                                                                                         | runs-on?                                                                                                     | DAGGER_CLOUD_TOKEN? |
-| [`publish.yaml`](references/ci-manifest.json)             | Publish                        | target, source?, registry?, chart?, tag?, version?, publish?, runs-on?                                                                                                                                                    | NPM_TOKEN?, CARGO_REGISTRY_TOKEN?, HELM_USERNAME?, HELM_PASSWORD?, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL? |
-| [`python-build-n-test.yaml`](references/ci-manifest.json) | Pipeline                       | Python Build & Test                                                                                                                                                                                                       | python-version?, runs-on?                                                                                    | DAGGER_CLOUD_TOKEN? |
-| [`release-compose.yaml`](references/ci-manifest.json)     | Release Compose                | image, context?, canary_label?, dockerfile?, ghcr?, ghcr_username?, dockerhub_username?, semver_prefix?, prepend_target?, target?, platforms?, download_artifact?, download_artifact_destination?, track_release_summary? | DOCKER_TOKEN?, GHCR_TOKEN?, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL?                                        |
-| [`release-docker.yaml`](references/ci-manifest.json)      | Release Docker                 | image, context?, canary_label?, dockerfile?, ghcr?, ghcr_username?, dockerhub_username?, semver_prefix?, prepend_target?, target?, platforms?, download_artifact?, download_artifact_destination?, track_release_summary? | DOCKER_TOKEN?, GHCR_TOKEN?, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL?                                        |
-| [`release-pnpm.yaml`](references/ci-manifest.json)        | Release pnpm                   | source?, registry?, tag?, version?, publish?, runs-on?                                                                                                                                                                    | NPM_TOKEN?, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL?                                                        |
-| [`rust-binary-release.yaml`](references/ci-manifest.json) | Rust Binary Release            | build_command?, binary_paths_csv, archive_name?, toolchain?, components?, runs-on?                                                                                                                                        | GH_TOKEN, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL?                                                          |
-| [`rust-build-n-test.yaml`](references/ci-manifest.json)   | Pipeline                       | Rust Build & Test                                                                                                                                                                                                         | toolchain?, components?, target?, name?, runs-on?                                                            | DAGGER_CLOUD_TOKEN? |
-| [`tagger.yaml`](references/ci-manifest.json)              | Reusable Tag Creation Workflow | prefix?, force?                                                                                                                                                                                                           | GH_TOKEN                                                                                                     |
-| [`update-readme.yaml`](references/ci-manifest.json)       | Update README                  | runs-on?                                                                                                                                                                                                                  | —                                                                                                            |
+| File | Name | Inputs (? = optional) | Secrets (? = optional) |
+| --- | --- | --- | --- |
+| [`audit.yaml`](references/ci-manifest.json) | Audit Workflow | runs-on?, semgrep_config?, include_gitleaks?, create_alerts?, track_release_summary? | DAGGER_CLOUD_TOKEN? |
+| [`codeql.yaml`](references/ci-manifest.json) | Security | Dagger Code Scan | semgrep_config?, include_gitleaks?, create_alerts?, runs-on? | DAGGER_CLOUD_TOKEN? |
+| [`dependency-review.yaml`](references/ci-manifest.json) | Security | Dagger Dependency Audit | runs-on?, semgrep_config?, create_alerts? | DAGGER_CLOUD_TOKEN? |
+| [`docker-release.yaml`](references/ci-manifest.json) | Docker Release Workflow | image, context?, canary_label?, dockerfile?, ghcr?, ghcr_username?, dockerhub_username?, semver_prefix?, prepend_target?, target?, platforms?, download_artifact?, download_artifact_destination?, track_release_summary? | DOCKER_TOKEN, GHCR_TOKEN?, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL? |
+| [`enforce-labels.yaml`](references/ci-manifest.json) | Enforce PR Labels | required_labels_any?, required_labels_any_description?, banned_labels?, runs-on? | DAGGER_CLOUD_TOKEN? |
+| [`pnpm-build-n-test.yaml`](references/ci-manifest.json) | Pipeline | pnpm Build & Test | runs-on? | DAGGER_CLOUD_TOKEN? |
+| [`publish.yaml`](references/ci-manifest.json) | Publish | target, source?, registry?, chart?, tag?, version?, publish?, runs-on? | NPM_TOKEN?, CARGO_REGISTRY_TOKEN?, HELM_USERNAME?, HELM_PASSWORD?, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL? |
+| [`python-build-n-test.yaml`](references/ci-manifest.json) | Pipeline | Python Build & Test | python-version?, runs-on? | DAGGER_CLOUD_TOKEN? |
+| [`release-compose.yaml`](references/ci-manifest.json) | Release Compose | image, context?, canary_label?, dockerfile?, ghcr?, ghcr_username?, dockerhub_username?, semver_prefix?, prepend_target?, target?, platforms?, download_artifact?, download_artifact_destination?, track_release_summary? | DOCKER_TOKEN?, GHCR_TOKEN?, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL? |
+| [`release-docker.yaml`](references/ci-manifest.json) | Release Docker | image, context?, canary_label?, dockerfile?, ghcr?, ghcr_username?, dockerhub_username?, semver_prefix?, prepend_target?, target?, platforms?, download_artifact?, download_artifact_destination?, track_release_summary? | DOCKER_TOKEN?, GHCR_TOKEN?, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL? |
+| [`release-pnpm.yaml`](references/ci-manifest.json) | Release pnpm | source?, registry?, tag?, version?, publish?, runs-on? | NPM_TOKEN?, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL? |
+| [`rust-binary-release.yaml`](references/ci-manifest.json) | Rust Binary Release | build_command?, binary_paths_csv, archive_name?, toolchain?, components?, runs-on? | GH_TOKEN, DAGGER_CLOUD_TOKEN?, DISCORD_WEBHOOK_URL? |
+| [`rust-build-n-test.yaml`](references/ci-manifest.json) | Pipeline | Rust Build & Test | toolchain?, components?, target?, name?, runs-on?, publish?, registry?, version?, publish_docs?, docs_path? | DAGGER_CLOUD_TOKEN?, CARGO_REGISTRY_TOKEN? |
+| [`rust-docs-publish.yaml`](references/ci-manifest.json) | Pipeline | Rust Docs Publish | toolchain?, components?, target?, docs_path?, runs-on? | DAGGER_CLOUD_TOKEN? |
+| [`tagger.yaml`](references/ci-manifest.json) | Reusable Tag Creation Workflow | prefix?, force? | GH_TOKEN |
+| [`update-readme.yaml`](references/ci-manifest.json) | Update README | runs-on? | — |
 
 ## Internal CI workflows
 
-- `internal-ci.yaml` — CI _(pull_request, push)_
-- `security.yaml` — Security _(pull_request, push, schedule)_
-- `test-code-matrix.yaml` — Test | Code Matrix _(pull_request, push)_
-- `test-docker-release.yaml` — Test | Docker Release Workflow _(pull_request, push)_
-- `test-graphql-action.yaml` — Test | GraphQL Query Default Branch _(push, pull_request)_
-- `test-install-cli.yaml` — Test | Install CLI Action _(pull_request, push)_
-- `test-pnpm-build-n-test.yaml` — Parity | pnpm Build & Test _(pull_request, push)_
-- `test-python-build-n-test.yaml` — Parity | Python Build & Test _(pull_request, push)_
-- `test-release-compose.yaml` — Test | Release Compose _(pull_request, push)_
-- `test-release-docker.yaml` — Test | Release Docker _(pull_request, push)_
-- `test-release-pnpm.yaml` — Test | Release pnpm _(pull_request, push)_
-- `test-rust-build-n-test.yaml` — Parity | Rust Build & Test _(pull_request, push)_
-- `test-semver.yaml` — Test | Semver Action _(pull_request, push)_
-- `test-setup-rust.yaml` — Test | Setup Rust _(pull_request, push)_
+- `internal-ci.yaml` — CI *(pull_request, push)*
+- `security.yaml` — Security *(pull_request, push, schedule)*
+- `spec-governance.yaml` — Governance | Spec Artifacts *(pull_request)*
+- `test-code-matrix.yaml` — Test | Code Matrix *(pull_request, push)*
+- `test-docker-release.yaml` — Test | Docker Release Workflow *(pull_request, push)*
+- `test-graphql-action.yaml` — Test | GraphQL Query Default Branch *(push, pull_request)*
+- `test-install-cli.yaml` — Test | Install CLI Action *(pull_request, push)*
+- `test-pnpm-build-n-test.yaml` — Parity | pnpm Build & Test *(pull_request, push)*
+- `test-python-build-n-test.yaml` — Parity | Python Build & Test *(pull_request, push)*
+- `test-release-compose.yaml` — Test | Release Compose *(pull_request, push)*
+- `test-release-docker.yaml` — Test | Release Docker *(pull_request, push)*
+- `test-release-pnpm.yaml` — Test | Release pnpm *(pull_request, push)*
+- `test-rust-build-n-test.yaml` — Parity | Rust Build & Test *(pull_request, push)*
+- `test-semver.yaml` — Test | Semver Action *(pull_request, push)*
+- `test-setup-rust.yaml` — Test | Setup Rust *(pull_request, push)*
 
 ## Dagger module functions
 
 Full param types in [references/ci-manifest.json](references/ci-manifest.json).
 
-| Function (kebab-case)   | Params (? = optional)                                                                                                                                                                                                                                                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ci`                    | source                                                                                                                                                                                                                                                                                                                                      |
-| `pnpm-build-and-test`   | source                                                                                                                                                                                                                                                                                                                                      |
-| `enforce-pr-labels`     | labelsCsv?, requiredAnyCsv?, bannedCsv?, requiredAnyDescription?                                                                                                                                                                                                                                                                            |
-| `notify-discord`        | webhookUrl, title, description?, color?, fieldsJson?, url?, footer?, username?                                                                                                                                                                                                                                                              |
-| `rust-build-and-test`   | source, toolchain?, components?, rustfmt", target?, name?                                                                                                                                                                                                                                                                                   |
-| `audit`                 | source, semgrepConfig?, includeGitleaks?                                                                                                                                                                                                                                                                                                    |
-| `publish-npm`           | source, registry?, token?, tag?, version?, publish?, discordWebhook?                                                                                                                                                                                                                                                                        |
-| `publish-pnpm`          | source, registry?, token?, tag?, version?, publish?, discordWebhook?                                                                                                                                                                                                                                                                        |
-| `publish-yarn`          | source, registry?, token?, tag?, version?, publish?, discordWebhook?                                                                                                                                                                                                                                                                        |
-| `publish-rust-crate`    | source, token?, version?, registry?, discordWebhook?                                                                                                                                                                                                                                                                                        |
-| `publish-helm-chart`    | source, chart?, registry?, username?, password?, version?, discordWebhook?                                                                                                                                                                                                                                                                  |
-| `docker-release`        | source, image, context?, dockerfile?, target?, platforms?, tagsCsv?, registriesCsv?, semverPrefix?, semverIncrement?, prependTarget?, canaryLabel?, dockerhubUsername?, ghcrUsername?, forcePush?, dockerToken?, ghcrToken?, eventName?, ref?, refName?, headRef?, defaultBranch?, sha?, runUrl?, runNumber?, prLabelsCsv?, discordWebhook? |
-| `ensure-repository`     | expectedRepository, repository?                                                                                                                                                                                                                                                                                                             |
-| `graphql-query`         | query, args?, token?, url?                                                                                                                                                                                                                                                                                                                  |
-| `install-cli`           | repository, asset, version?, overrideName?, token?                                                                                                                                                                                                                                                                                          |
-| `setup-rust`            | source, toolchain?, components?, rustfmt", target?, crates?                                                                                                                                                                                                                                                                                 |
-| `python-build-and-test` | source, pythonVersion?                                                                                                                                                                                                                                                                                                                      |
-| `setup-node`            | source, nodeVersion?, packageManager?, installDeps?                                                                                                                                                                                                                                                                                         |
-| `setup-go`              | source, goVersion?                                                                                                                                                                                                                                                                                                                          |
-| `setup-ruby`            | source, rubyVersion?, bundleInstall?                                                                                                                                                                                                                                                                                                        |
-| `setup-java`            | source, javaVersion?, distribution?                                                                                                                                                                                                                                                                                                         |
-| `setup-terraform`       | source, terraformVersion?, useOpentofu?                                                                                                                                                                                                                                                                                                     |
-| `setup-pulumi`          | source, pulumiVersion?, runtime?                                                                                                                                                                                                                                                                                                            |
-| `rust-binary-release`   | source, binaryPathsCsv, tag, ghToken, buildCommand?, archiveName?, toolchain?, components?, rustfmt", repository?, discordWebhook?                                                                                                                                                                                                          |
-| `compute-semver`        | tagsCsv?, base?, prefix?, increment?, prLabelsCsv?, branchName?, majorLabel?, minorLabel?, patchLabel?                                                                                                                                                                                                                                      |
-| `docker-facts`          | source, image, version, registries?, dockerfile?, context?, canaryLabel?, forcePush?, withLatest?, target?, prependTarget?, eventName?, ref?, defaultBranch?, prLabelsCsv?                                                                                                                                                                  |
-| `code-matrix`           | source                                                                                                                                                                                                                                                                                                                                      |
+| Function (kebab-case) | Params (? = optional) |
+| --- | --- |
+| `ci` | source |
+| `pnpm-build-and-test` | source |
+| `enforce-pr-labels` | labelsCsv?, requiredAnyCsv?, bannedCsv?, requiredAnyDescription? |
+| `notify-discord` | webhookUrl, title, description?, color?, fieldsJson?, url?, footer?, username? |
+| `rust-build-and-test` | source, toolchain?, components?, target?, name? |
+| `rust-docs-build` | source, toolchain?, components?, target?, docsPath? |
+| `rust-pipeline` | source, toolchain?, components?, target?, name?, publish?, token?, registry?, version?, publishDocs?, docsPath? |
+| `audit` | source, semgrepConfig?, includeGitleaks? |
+| `publish-npm` | source, registry?, token?, tag?, version?, publish?, discordWebhook? |
+| `publish-pnpm` | source, registry?, token?, tag?, version?, publish?, discordWebhook? |
+| `publish-yarn` | source, registry?, token?, tag?, version?, publish?, discordWebhook? |
+| `publish-rust-crate` | source, token?, version?, registry?, discordWebhook? |
+| `publish-helm-chart` | source, chart?, registry?, username?, password?, version?, discordWebhook? |
+| `docker-release` | source, image, context?, dockerfile?, target?, platforms?, tagsCsv?, registriesCsv?, semverPrefix?, semverIncrement?, prependTarget?, canaryLabel?, dockerhubUsername?, ghcrUsername?, forcePush?, dockerToken?, ghcrToken?, eventName?, ref?, refName?, headRef?, defaultBranch?, sha?, runUrl?, runNumber?, prLabelsCsv?, discordWebhook? |
+| `ensure-repository` | expectedRepository, repository? |
+| `graphql-query` | query, args?, token?, url? |
+| `install-cli` | repository, asset, version?, overrideName?, token? |
+| `setup-rust` | source, toolchain?, components?, target?, crates? |
+| `python-build-and-test` | source, pythonVersion? |
+| `setup-node` | source, nodeVersion?, packageManager?, installDeps? |
+| `setup-go` | source, goVersion? |
+| `setup-ruby` | source, rubyVersion?, bundleInstall? |
+| `setup-java` | source, javaVersion?, distribution? |
+| `setup-terraform` | source, terraformVersion?, useOpentofu? |
+| `setup-pulumi` | source, pulumiVersion?, runtime? |
+| `rust-binary-release` | source, binaryPathsCsv, tag, ghToken, buildCommand?, archiveName?, toolchain?, components?, repository?, discordWebhook? |
+| `compute-semver` | tagsCsv?, base?, prefix?, increment?, prLabelsCsv?, branchName?, majorLabel?, minorLabel?, patchLabel? |
+| `docker-facts` | source, image, version, registries?, dockerfile?, context?, canaryLabel?, forcePush?, withLatest?, target?, prependTarget?, eventName?, ref?, defaultBranch?, prLabelsCsv? |
+| `code-matrix` | source |
 
 ## Common patterns
 
@@ -189,12 +193,12 @@ push to main
 
 ### Secrets reference
 
-| Secret                 | Scope                                         |
-| ---------------------- | --------------------------------------------- |
-| `DAGGER_CLOUD_TOKEN`   | All Dagger workflows (optional — cloud cache) |
-| `DISCORD_WEBHOOK_URL`  | All publish/release/test workflows (optional) |
-| `DOCKER_TOKEN`         | `docker-release.yaml`                         |
-| `GHCR_TOKEN`           | `docker-release.yaml` when `ghcr: true`       |
-| `NPM_TOKEN`            | `publish.yaml` node target                    |
-| `CARGO_REGISTRY_TOKEN` | `publish.yaml` rust-crate target              |
-| `GH_TOKEN`             | `tagger.yaml`, `rust-binary-release.yaml`     |
+| Secret | Scope |
+| --- | --- |
+| `DAGGER_CLOUD_TOKEN` | All Dagger workflows (optional — cloud cache) |
+| `DISCORD_WEBHOOK_URL` | All publish/release/test workflows (optional) |
+| `DOCKER_TOKEN` | `docker-release.yaml` |
+| `GHCR_TOKEN` | `docker-release.yaml` when `ghcr: true` |
+| `NPM_TOKEN` | `publish.yaml` node target |
+| `CARGO_REGISTRY_TOKEN` | `publish.yaml` rust-crate target |
+| `GH_TOKEN` | `tagger.yaml`, `rust-binary-release.yaml` |

--- a/skills/ci/references/ci-manifest.json
+++ b/skills/ci/references/ci-manifest.json
@@ -1,12 +1,14 @@
 {
-  "generatedAt": "2026-06-19",
+  "generatedAt": "2026-07-13",
   "daggerVersion": "v0.x",
   "moduleRef": "github.com/mbround18/gh-reusable/packages/dagger-module@main",
   "reusableWorkflows": [
     {
       "file": "audit.yaml",
       "name": "Audit Workflow",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -56,7 +58,9 @@
     {
       "file": "codeql.yaml",
       "name": "Security | Dagger Code Scan",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -99,7 +103,9 @@
     {
       "file": "dependency-review.yaml",
       "name": "Security | Dagger Dependency Audit",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -135,7 +141,9 @@
     {
       "file": "docker-release.yaml",
       "name": "Docker Release Workflow",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -263,7 +271,9 @@
     {
       "file": "enforce-labels.yaml",
       "name": "Enforce PR Labels",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -306,7 +316,9 @@
     {
       "file": "pnpm-build-n-test.yaml",
       "name": "Pipeline | pnpm Build & Test",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -328,7 +340,9 @@
     {
       "file": "publish.yaml",
       "name": "Publish",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -424,7 +438,9 @@
     {
       "file": "python-build-n-test.yaml",
       "name": "Pipeline | Python Build & Test",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -453,7 +469,9 @@
     {
       "file": "release-compose.yaml",
       "name": "Release Compose",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -581,7 +599,9 @@
     {
       "file": "release-docker.yaml",
       "name": "Release Docker",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -709,7 +729,9 @@
     {
       "file": "release-pnpm.yaml",
       "name": "Release pnpm",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -776,7 +798,9 @@
     {
       "file": "rust-binary-release.yaml",
       "name": "Rust Binary Release",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -843,7 +867,9 @@
     {
       "file": "rust-build-n-test.yaml",
       "name": "Pipeline | Rust Build & Test",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -880,6 +906,98 @@
           "required": false,
           "default": "ubuntu-latest",
           "description": "GitHub runner to use for this workflow."
+        },
+        {
+          "name": "publish",
+          "type": "boolean",
+          "required": false,
+          "default": false,
+          "description": "Whether to publish the crate after a successful build/test run."
+        },
+        {
+          "name": "registry",
+          "type": "string",
+          "required": false,
+          "default": "crates.io",
+          "description": "Cargo registry to publish to when publish=true."
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "Optional publish version override."
+        },
+        {
+          "name": "publish_docs",
+          "type": "boolean",
+          "required": false,
+          "default": false,
+          "description": "Whether to generate Rust docs and publish them to GitHub Pages."
+        },
+        {
+          "name": "docs_path",
+          "type": "string",
+          "required": false,
+          "default": "target/doc",
+          "description": "Path to generated docs for GitHub Pages upload."
+        }
+      ],
+      "secrets": [
+        {
+          "name": "DAGGER_CLOUD_TOKEN",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "CARGO_REGISTRY_TOKEN",
+          "required": false,
+          "description": ""
+        }
+      ]
+    },
+    {
+      "file": "rust-docs-publish.yaml",
+      "name": "Pipeline | Rust Docs Publish",
+      "triggers": [
+        "workflow_call"
+      ],
+      "isReusable": true,
+      "inputs": [
+        {
+          "name": "toolchain",
+          "type": "string",
+          "required": false,
+          "default": "1.95",
+          "description": "Rust toolchain to use (for example 1.95, nightly, beta)."
+        },
+        {
+          "name": "components",
+          "type": "string",
+          "required": false,
+          "default": "clippy,rustfmt",
+          "description": "Comma-separated list of Rust components to install."
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "Comma-separated list of additional Rust compilation targets."
+        },
+        {
+          "name": "docs_path",
+          "type": "string",
+          "required": false,
+          "default": "target/doc",
+          "description": "Path to generated Rust docs for GitHub Pages upload."
+        },
+        {
+          "name": "runs-on",
+          "type": "string",
+          "required": false,
+          "default": "ubuntu-latest",
+          "description": "GitHub runner to use for this workflow."
         }
       ],
       "secrets": [
@@ -893,7 +1011,9 @@
     {
       "file": "tagger.yaml",
       "name": "Reusable Tag Creation Workflow",
-      "triggers": ["workflow_call"],
+      "triggers": [
+        "workflow_call"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -922,7 +1042,11 @@
     {
       "file": "update-readme.yaml",
       "name": "Update README",
-      "triggers": ["workflow_call", "workflow_dispatch", "push"],
+      "triggers": [
+        "workflow_call",
+        "workflow_dispatch",
+        "push"
+      ],
       "isReusable": true,
       "inputs": [
         {
@@ -940,7 +1064,10 @@
     {
       "file": "internal-ci.yaml",
       "name": "CI",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -948,7 +1075,21 @@
     {
       "file": "security.yaml",
       "name": "Security",
-      "triggers": ["pull_request", "push", "schedule"],
+      "triggers": [
+        "pull_request",
+        "push",
+        "schedule"
+      ],
+      "isReusable": false,
+      "inputs": [],
+      "secrets": []
+    },
+    {
+      "file": "spec-governance.yaml",
+      "name": "Governance | Spec Artifacts",
+      "triggers": [
+        "pull_request"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -956,7 +1097,10 @@
     {
       "file": "test-code-matrix.yaml",
       "name": "Test | Code Matrix",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -964,7 +1108,10 @@
     {
       "file": "test-docker-release.yaml",
       "name": "Test | Docker Release Workflow",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -972,7 +1119,10 @@
     {
       "file": "test-graphql-action.yaml",
       "name": "Test | GraphQL Query Default Branch",
-      "triggers": ["push", "pull_request"],
+      "triggers": [
+        "push",
+        "pull_request"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -980,7 +1130,10 @@
     {
       "file": "test-install-cli.yaml",
       "name": "Test | Install CLI Action",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -988,7 +1141,10 @@
     {
       "file": "test-pnpm-build-n-test.yaml",
       "name": "Parity | pnpm Build & Test",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -996,7 +1152,10 @@
     {
       "file": "test-python-build-n-test.yaml",
       "name": "Parity | Python Build & Test",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -1004,7 +1163,10 @@
     {
       "file": "test-release-compose.yaml",
       "name": "Test | Release Compose",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -1012,7 +1174,10 @@
     {
       "file": "test-release-docker.yaml",
       "name": "Test | Release Docker",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -1020,7 +1185,10 @@
     {
       "file": "test-release-pnpm.yaml",
       "name": "Test | Release pnpm",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -1028,7 +1196,10 @@
     {
       "file": "test-rust-build-n-test.yaml",
       "name": "Parity | Rust Build & Test",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -1036,7 +1207,10 @@
     {
       "file": "test-semver.yaml",
       "name": "Test | Semver Action",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -1044,7 +1218,10 @@
     {
       "file": "test-setup-rust.yaml",
       "name": "Test | Setup Rust",
-      "triggers": ["pull_request", "push"],
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
       "isReusable": false,
       "inputs": [],
       "secrets": []
@@ -1258,9 +1435,66 @@
           "optional": true
         },
         {
-          "name": "rustfmt\"",
-          "type": "unknown",
+          "name": "target",
+          "type": "string",
+          "optional": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "optional": true
+        }
+      ]
+    },
+    {
+      "camel": "rustDocsBuild",
+      "kebab": "rust-docs-build",
+      "params": [
+        {
+          "name": "source",
+          "type": "Directory",
           "optional": false
+        },
+        {
+          "name": "toolchain",
+          "type": "string",
+          "optional": true
+        },
+        {
+          "name": "components",
+          "type": "string",
+          "optional": true
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "optional": true
+        },
+        {
+          "name": "docsPath",
+          "type": "string",
+          "optional": true
+        }
+      ]
+    },
+    {
+      "camel": "rustPipeline",
+      "kebab": "rust-pipeline",
+      "params": [
+        {
+          "name": "source",
+          "type": "Directory",
+          "optional": false
+        },
+        {
+          "name": "toolchain",
+          "type": "string",
+          "optional": true
+        },
+        {
+          "name": "components",
+          "type": "string",
+          "optional": true
         },
         {
           "name": "target",
@@ -1269,6 +1503,36 @@
         },
         {
           "name": "name",
+          "type": "string",
+          "optional": true
+        },
+        {
+          "name": "publish",
+          "type": "boolean",
+          "optional": true
+        },
+        {
+          "name": "token",
+          "type": "string",
+          "optional": true
+        },
+        {
+          "name": "registry",
+          "type": "string",
+          "optional": true
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "optional": true
+        },
+        {
+          "name": "publishDocs",
+          "type": "boolean",
+          "optional": true
+        },
+        {
+          "name": "docsPath",
           "type": "string",
           "optional": true
         }
@@ -1724,11 +1988,6 @@
           "optional": true
         },
         {
-          "name": "rustfmt\"",
-          "type": "unknown",
-          "optional": false
-        },
-        {
           "name": "target",
           "type": "string",
           "optional": true
@@ -1925,11 +2184,6 @@
           "name": "components",
           "type": "string",
           "optional": true
-        },
-        {
-          "name": "rustfmt\"",
-          "type": "unknown",
-          "optional": false
         },
         {
           "name": "repository",

--- a/specs/002-reusable-rust-pipeline/checklists/contract-matrix.md
+++ b/specs/002-reusable-rust-pipeline/checklists/contract-matrix.md
@@ -1,0 +1,9 @@
+# Rust Pipeline Contract Matrix
+
+| Surface | Contract | Status | Evidence |
+| --- | --- | --- | --- |
+| `.github/workflows/rust-build-n-test.yaml` | Build/test defaults with optional `publish` and `publish_docs` | Implemented | workflow inputs + `rust-pipeline` call wiring |
+| `.github/workflows/rust-build-n-test.yaml` | `CARGO_REGISTRY_TOKEN` required only when publish is enabled | Implemented | `--publish` + `--token` to `rust-pipeline`; fail-fast in Dagger |
+| `.github/workflows/rust-docs-publish.yaml` | Shared docs-to-GitHub-Pages reusable path | Implemented | new reusable workflow with Pages deploy |
+| `packages/dagger-module/src/index.ts` | Public `@func()` orchestration for Rust modes | Implemented | `rustPipeline` and `rustDocsBuild` |
+| `packages/dagger-pipelines/src/*.test.ts` | Governance coverage for workflow contracts and call names | Implemented | rust/security/release/workflow-governance test additions |

--- a/specs/002-reusable-rust-pipeline/checklists/docs-pages-prereqs.md
+++ b/specs/002-reusable-rust-pipeline/checklists/docs-pages-prereqs.md
@@ -1,0 +1,7 @@
+# Docs Publish Prerequisites
+
+- [x] Repository has GitHub Pages configured for Actions deployment (`github-pages` environment).
+- [x] Workflow has `pages: write` and `id-token: write` only in docs deployment job.
+- [x] Rust docs output path is configurable via `docs_path`.
+- [x] Docs deployment is opt-in through `publish_docs`.
+- [x] Docs path validation emits actionable failure guidance before upload/deploy.

--- a/specs/002-reusable-rust-pipeline/checklists/requirements.md
+++ b/specs/002-reusable-rust-pipeline/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Reusable Rust Pipeline Architecture
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed in one iteration.
+- Publish gating, conditional secret requirements, docs publication path, and compatibility expectations are explicitly defined.

--- a/specs/002-reusable-rust-pipeline/checklists/validation-log.md
+++ b/specs/002-reusable-rust-pipeline/checklists/validation-log.md
@@ -1,0 +1,15 @@
+# Validation Log: Reusable Rust Pipeline Architecture
+
+## Focused governance validations
+
+- ✅ `pnpm --filter @gh-reusable/dagger-pipelines run test -- src/workflow-governance.test.ts src/dagger-module-integration.test.ts src/rust-workflow.test.ts src/publish-workflow.test.ts src/release-workflows.test.ts src/security-workflows.test.ts src/standards-defaults.test.ts src/workflows.test.ts`
+  - Result: 15 test files passed, 51 tests passed.
+- ✅ `pnpm --filter ./packages/dagger-module run test`
+  - Result: 6 test files passed, 66 tests passed.
+- ✅ `pnpm --filter @gh-reusable/dagger-pipelines run test:compliance`
+  - Result: all compliance aliases (`us1`, `us2`, `us3`) completed successfully.
+
+## Workspace validations
+
+- ✅ `pnpm run typecheck && pnpm run test`
+  - Result: command completed successfully (exit code 0).

--- a/specs/002-reusable-rust-pipeline/contracts/reusable-rust-pipeline-contract.md
+++ b/specs/002-reusable-rust-pipeline/contracts/reusable-rust-pipeline-contract.md
@@ -1,0 +1,55 @@
+# Reusable Rust Pipeline Contract
+
+This contract defines externally visible behavior for the reusable Rust pipeline and its compatibility with existing Rust workflow surfaces.
+
+## 1) Reusable Workflow Interface Contract (`.github/workflows/*`)
+
+- The reusable Rust contract MUST execute build/test by default.
+- Publish and docs publish MUST be explicit opt-in inputs and default to disabled.
+- Inputs/secrets declared in workflow_call MUST be referenced in workflow implementation.
+- Secrets contract must distinguish:
+  - always-optional secrets,
+  - conditionally-required secrets (for publish/docs modes).
+
+## 2) Dagger Public Function Contract (`packages/dagger-module/src/index.ts`)
+
+- Workflow call names MUST align with kebab-case `@func()` names.
+- Rust baseline and optional publish/docs behavior MUST be implemented in Dagger contracts, not workflow shell logic.
+- Publish contract MUST fail early with clear error when publish intent is enabled but token is missing.
+- Canonical publish secret name is `CARGO_REGISTRY_TOKEN`; publish-enabled runs must fail before mutation if it is absent.
+- Any new docs-related `@func()` is a public contract surface and must be included in integration tests.
+
+## 3) Permission and Security Contract
+
+- Default mode (build/test only) uses least-privilege permissions.
+- Publish/docs permissions elevate only in corresponding enabled modes.
+- Secret use must be explicit in the contract and must not be required when the mode is disabled.
+
+## 4) Compatibility Contract
+
+- Existing `rust-build-n-test` consumers remain supported without changing build/test intent.
+- Existing rust publish consumers using `publish.yaml` target `rust-crate` remain supported.
+- Migration to unified contract is additive and phased; no forced breaking change for baseline consumers.
+
+### Baseline invocation contract
+
+- The reusable Rust workflow invokes Dagger `rust-pipeline` with:
+  - `publish=false` by default,
+  - `publish_docs=false` by default,
+  - `toolchain`, `components`, `target`, and `name` passthrough unchanged from previous build/test surface.
+- `CARGO_REGISTRY_TOKEN` is conditionally required only when `publish=true`.
+- Docs deployment is delegated through shared reusable workflow `.github/workflows/rust-docs-publish.yaml`.
+
+## 5) Governance Test Contract (`packages/dagger-pipelines`)
+
+Required coverage for this feature:
+
+- `src/workflow-governance.test.ts` for input/secret reference integrity.
+- `src/dagger-module-integration.test.ts` for `@func()` ↔ workflow call alignment.
+- `src/publish-workflow.test.ts` and `src/release-workflows.test.ts` for publish/release compatibility.
+- `src/standards-defaults.test.ts` for toolchain/defaults alignment and explicit permissions.
+
+## Versioning and Change Policy
+
+- Default expectation: non-breaking for existing Rust consumers.
+- If any breaking behavior becomes necessary, release notes must include migration and rollback guidance plus explicit compatibility classification.

--- a/specs/002-reusable-rust-pipeline/data-model.md
+++ b/specs/002-reusable-rust-pipeline/data-model.md
@@ -1,0 +1,82 @@
+# Data Model: Reusable Rust Pipeline Architecture
+
+## Entity: RustPipelineInvocation
+
+- **Fields**
+  - `workflowRef` (string; reusable workflow identifier)
+  - `toolchain` (string; defaults to repository Rust standard)
+  - `components` (string CSV; defaults to `clippy,rustfmt`)
+  - `target` (string CSV; optional additional targets)
+  - `publishEnabled` (boolean; default `false`)
+  - `docsPublishEnabled` (boolean; default `false`)
+  - `runsOn` (string; runner label)
+- **Validation Rules**
+  - `publishEnabled=false` and `docsPublishEnabled=false` must still execute baseline build/test.
+  - `toolchain` default must align with `defaults.json`.
+
+## Entity: ConditionalSecretRequirement
+
+- **Fields**
+  - `secretName` (enum: `CARGO_REGISTRY_TOKEN`, docs deploy secret(s))
+  - `requiredWhen` (expression over pipeline mode flags)
+  - `failureMessage` (string)
+- **Validation Rules**
+  - `CARGO_REGISTRY_TOKEN` required only when `publishEnabled=true`.
+  - Missing required conditional secret must fail before mutating operations.
+
+## Entity: RustPublishOperation
+
+- **Fields**
+  - `target` (string; `rust-crate`)
+  - `registry` (string; default `crates.io`)
+  - `versionOverride` (string; optional)
+  - `publishAttempted` (boolean)
+  - `publishResult` (enum: `skipped`, `success`, `failed`)
+- **Validation Rules**
+  - `publishAttempted=true` only when `publishEnabled=true`.
+  - `publishResult=skipped` when publish intent is disabled.
+
+## Entity: RustDocsPublishOperation
+
+- **Fields**
+  - `docsPublishEnabled` (boolean)
+  - `docsBuildSucceeded` (boolean)
+  - `pagesPublishAttempted` (boolean)
+  - `pagesPublishResult` (enum: `skipped`, `success`, `failed`)
+  - `artifactPath` (string; docs output path)
+- **Validation Rules**
+  - Docs publish requires successful baseline checks.
+  - Empty/invalid docs artifact must produce actionable failure.
+  - `pagesPublishAttempted=false` when docs mode disabled.
+
+## Entity: CompatibilityAdapterContract
+
+- **Fields**
+  - `legacySurface` (enum: `rust-build-n-test`, `publish-rust-crate`)
+  - `newSurface` (string; new reusable Rust contract mapping)
+  - `compatibilityMode` (enum: `full`, `transitional`)
+  - `migrationNotes` (string)
+- **Validation Rules**
+  - Existing build/test-only consumers must remain non-breaking.
+  - Publish consumers must retain explicit token-gated behavior.
+
+## Relationships
+
+- `RustPipelineInvocation` 1→1 `RustPublishOperation` (optional execution)
+- `RustPipelineInvocation` 1→1 `RustDocsPublishOperation` (optional execution)
+- `RustPipelineInvocation` 1→N `ConditionalSecretRequirement`
+- `CompatibilityAdapterContract` maps legacy surfaces to new invocation paths
+
+## State Transitions
+
+### RustPublishOperation
+
+- `skipped` (default) → `success` (publish enabled + valid token + checks pass)
+- `skipped` (default) → `failed` (publish enabled + validation/check failure)
+- `failed` → `success` (after remediation and rerun)
+
+### RustDocsPublishOperation
+
+- `skipped` (default) → `success` (docs enabled + docs generation + pages publish pass)
+- `skipped` (default) → `failed` (docs enabled but preconditions/artifacts invalid)
+- `failed` → `success` (after remediation and rerun)

--- a/specs/002-reusable-rust-pipeline/plan.md
+++ b/specs/002-reusable-rust-pipeline/plan.md
@@ -1,0 +1,176 @@
+# Implementation Plan: Reusable Rust Pipeline Architecture
+
+## Inputs
+
+- Linked feature spec: `specs/002-reusable-rust-pipeline/spec.md`
+- Affected paths:
+  - `.github/workflows/rust-build-n-test.yaml`
+  - `.github/workflows/rust-docs-publish.yaml`
+  - `.github/workflows/publish.yaml`
+  - `.github/workflows/test-rust-build-n-test.yaml`
+  - `.github/actions/dagger-run/action.yml` (wiring-only verification)
+  - `packages/dagger-module/src/index.ts`
+  - `packages/dagger-module/src/types.ts`
+  - `packages/dagger-module/src/reporting.ts`
+  - `packages/dagger-pipelines/src/*.test.ts` (governance/compatibility)
+  - `packages/dagger-pipelines/src/workflows.ts` (shared compliance helpers)
+  - `packages/dagger-pipelines/package.json` (focused compliance scripts if needed)
+
+## Summary
+
+Add an additive reusable Rust pipeline contract that keeps build/test as the default, adds explicit opt-in publish/docs modes, and preserves compatibility for current `rust-build-n-test` and publish consumers via thin workflow adapters backed by Dagger `@func()` contracts.
+
+## Technical Context
+
+**Language/Version**: TypeScript (workspace baseline), YAML reusable workflow contracts, Dagger module functions, Rust toolchain defaults via `defaults.json`  
+**Primary Dependencies**: `@dagger.io/dagger`, `vitest`, `yaml`, reusable workflow_call interfaces  
+**Storage**: Repository files and workflow contract declarations  
+**Testing**: `pnpm run test`, `pnpm run typecheck`, `pnpm --filter @gh-reusable/dagger-pipelines run test -- ...`  
+**Target Platform**: GitHub Actions (`ubuntu-latest`) and local Linux/macOS development  
+**Project Type**: Monorepo (reusable workflows + Dagger-first execution + governance test suite)  
+**Constraints**: Workflows stay thin; core behavior in `packages/dagger-module/src/index.ts`; least-privilege permissions; non-breaking migration for existing Rust consumers  
+**Scale/Scope**: Rust workflow contract surfaces (`rust-build-n-test`, `publish`) and Dagger Rust/publication entrypoints  
+
+Resolved clarifications from Phase 0 are captured in `research.md`:
+- No existing reusable GitHub Pages docs publish workflow exists today.
+- Current compatibility surfaces are `rust-build-n-test.yaml` and `publish.yaml` (`target: rust-crate`).
+- Governance tests already enforce workflow input/secret usage and Dagger call-name alignment.
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+`.specify/memory/constitution.md` is not present in this repository. For this feature, gates are derived from repository-enforced governance and must be treated as provisional until a constitution artifact exists:
+
+1. **Dagger-First Gate** — Workflow YAML remains adapter-only; behavior changes land in Dagger module `@func()` logic.
+2. **Contract Integrity Gate** — `workflow_call` inputs/secrets, Dagger call names, and public `@func()` entrypoints remain aligned and validated by tests.
+3. **Security Gate** — Default permissions stay least-privilege; publish/docs scopes only elevate when enabled.
+4. **Compatibility Gate** — Existing `rust-build-n-test` and `publish` contracts remain usable for downstream consumers.
+
+**Pre-Phase 0 Gate Status**: PROVISIONAL PASS (derived gates only)
+
+## Phase 0 Research Summary
+
+See `specs/002-reusable-rust-pipeline/research.md`.
+
+Key outcomes:
+- Reuse existing Rust call naming conventions (`rust-build-and-test`, `publish-rust-crate`) and add new docs call with kebab-case alignment.
+- Add docs publishing as an explicit opt-in contract path (no default mutation).
+- Extend governance tests to cover new Rust reusable contract surfaces and compatibility expectations.
+
+## Phase 1 Design Artifacts
+
+- Data model: `specs/002-reusable-rust-pipeline/data-model.md`
+- Contracts: `specs/002-reusable-rust-pipeline/contracts/reusable-rust-pipeline-contract.md`
+- Quickstart: `specs/002-reusable-rust-pipeline/quickstart.md`
+
+## Design Decisions
+
+- Add one reusable Rust pipeline contract surface that always runs build/test and conditionally executes publish/docs branches.
+- Keep workflow logic thin and delegate mode handling/gating to Dagger module `@func()` contracts.
+- Preserve existing consumer behavior through additive adapter strategy:
+  - Keep `.github/workflows/rust-build-n-test.yaml` interface stable.
+  - Keep `.github/workflows/publish.yaml` rust-crate path stable.
+  - Introduce migration-compatible path for docs publish without forcing current consumers to change.
+- Validate with governance tests in `packages/dagger-pipelines` (workflow, integration, publish/release compatibility).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-reusable-rust-pipeline/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── contracts/
+    └── reusable-rust-pipeline-contract.md
+```
+
+### Source Code (planned implementation touch points)
+
+```text
+.github/workflows/
+├── rust-build-n-test.yaml
+├── rust-docs-publish.yaml
+├── publish.yaml
+└── test-rust-build-n-test.yaml
+
+packages/dagger-module/src/
+├── index.ts
+├── reporting.ts
+└── types.ts
+
+packages/dagger-pipelines/src/
+├── workflows.ts
+├── workflow-governance.test.ts
+├── dagger-module-integration.test.ts
+├── rust-workflow.test.ts
+├── publish-workflow.test.ts
+├── release-workflows.test.ts
+├── security-workflows.test.ts
+└── standards-defaults.test.ts
+```
+
+## Work Breakdown
+
+1. **Workflow contract updates**
+   - Define/reinforce reusable Rust inputs and conditional secrets.
+   - Add docs publish contract surface with explicit opt-in defaults.
+   - Ensure permission scopes are mode-specific and least-privilege.
+2. **Dagger contract updates**
+   - Add/adjust Rust `@func()` entrypoint(s) for unified baseline + optional publish/docs operations.
+   - Enforce fail-fast token checks when publish is enabled.
+   - Keep call names kebab-case compatible for workflow invocation.
+3. **Governance/tests updates**
+   - Extend `packages/dagger-pipelines` tests for new contract keys, call names, and compatibility paths.
+   - Add/adjust focused compliance scripts when new tests are added.
+4. **Rollout and compatibility**
+   - Additive rollout preserving existing `rust-build-n-test` and `publish` consumers.
+   - Validate parity in repo-level test workflows before recommending downstream migration.
+
+## Contract Safety Checklist
+
+- [x] Reusable workflow input/secret declarations match usage
+- [x] Dagger call names remain aligned with module `@func()` names
+- [x] Defaults are sourced from `defaults.json` where applicable
+- [x] Permissions are explicit and least-privilege
+- [x] Publish/docs toggles are opt-in and fail-safe
+- [x] Existing `rust-build-n-test` and publish consumers retain compatibility
+
+## Validation Matrix
+
+| Contract surface | Validation |
+| --- | --- |
+| Rust reusable workflow wiring and declarations | `pnpm --filter @gh-reusable/dagger-pipelines run test -- src/workflow-governance.test.ts` |
+| Dagger `@func()` ↔ workflow call-name alignment | `pnpm --filter @gh-reusable/dagger-pipelines run test -- src/dagger-module-integration.test.ts` |
+| Publish workflow interface + compatibility | `pnpm --filter @gh-reusable/dagger-pipelines run test -- src/publish-workflow.test.ts src/release-workflows.test.ts` |
+| Runtime default/toolchain consistency | `pnpm --filter @gh-reusable/dagger-pipelines run test -- src/standards-defaults.test.ts` |
+| Security/audit baseline regression | `pnpm --filter @gh-reusable/dagger-pipelines run test -- src/security-workflows.test.ts src/audit-workflow.test.ts` |
+| Workspace confidence | `pnpm run typecheck && pnpm run test` |
+
+## Rollout and Compatibility Strategy
+
+1. Ship additive reusable Rust pipeline changes with defaults equivalent to current build/test behavior.
+2. Keep current `rust-build-n-test` and `publish` interfaces operational while introducing docs mode.
+3. Validate compatibility via existing and updated governance suites before downstream rollout.
+4. Migrate downstream repos in phases:
+   - Phase A: build/test only
+   - Phase B: publish enabled repos
+   - Phase C: docs-enabled repos
+5. Rollback plan:
+   - Revert callers to prior workflow refs and disable publish/docs flags.
+   - Preserve baseline build/test path as safe default.
+
+## Post-Design Constitution Check
+
+All four gates remain satisfied by this design. No unresolved constitutional violations.
+
+## Implementation Notes (Completed)
+
+- Added shared reusable docs workflow `.github/workflows/rust-docs-publish.yaml` with Pages-scoped permissions and contract-safe docs-path validation.
+- Updated `.github/workflows/rust-build-n-test.yaml` to invoke Dagger `rust-pipeline` with publish/docs opt-in inputs and conditional token wiring.
+- Added Dagger `@func()` contracts `rustPipeline` and `rustDocsBuild` in `packages/dagger-module/src/index.ts` with mode-aware reporting outputs.
+- Extended report/type surfaces for rust mode outcomes in `packages/dagger-module/src/reporting.ts` and `packages/dagger-module/src/types.ts`.
+- Added governance coverage across workflow, release, security, integration, and rust-specific tests.

--- a/specs/002-reusable-rust-pipeline/quickstart.md
+++ b/specs/002-reusable-rust-pipeline/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart Validation Guide: Reusable Rust Pipeline Architecture
+
+This guide validates contract behavior for baseline Rust CI, optional crates publish, and optional docs publication.
+
+## Prerequisites
+
+- Node + pnpm installed
+- Workspace dependencies installed
+
+## Setup
+
+```bash
+pnpm install
+```
+
+## Scenario A: Governance baseline for reusable workflow + Dagger contracts
+
+```bash
+pnpm --filter @gh-reusable/dagger-pipelines run test -- src/workflow-governance.test.ts
+pnpm --filter @gh-reusable/dagger-pipelines run test -- src/dagger-module-integration.test.ts
+```
+
+Expected outcome:
+- Workflow inputs/secrets and Dagger call names are contract-valid.
+
+## Scenario B: Rust publish/release compatibility surfaces
+
+```bash
+pnpm --filter @gh-reusable/dagger-pipelines run test -- src/publish-workflow.test.ts src/release-workflows.test.ts
+```
+
+Expected outcome:
+- Existing publish contract remains compatible.
+- Rust publish path still maps to expected Dagger contract entrypoints.
+
+## Scenario C: Optional docs publication contract and failure messaging
+
+```bash
+pnpm --filter @gh-reusable/dagger-pipelines run test -- src/rust-workflow.test.ts src/release-workflows.test.ts
+```
+
+Expected outcome:
+- Docs mode remains opt-in via `publish_docs`.
+- Reusable docs workflow wiring (`rust-docs-publish.yaml`) is present.
+- Actionable docs-path failure guidance is enforced in tests.
+
+## Scenario D: Runtime defaults + permission posture
+
+```bash
+pnpm --filter @gh-reusable/dagger-pipelines run test -- src/standards-defaults.test.ts src/security-workflows.test.ts src/audit-workflow.test.ts
+```
+
+Expected outcome:
+- Rust defaults align with `defaults.json`.
+- Reusable workflows continue declaring explicit permissions and security behavior.
+
+## Scenario E: Full workspace confidence
+
+```bash
+pnpm run typecheck
+pnpm run test
+```
+
+Expected outcome:
+- No cross-package regressions.
+
+## Focused compliance aliases
+
+```bash
+pnpm --filter @gh-reusable/dagger-pipelines run test:compliance:us1
+pnpm --filter @gh-reusable/dagger-pipelines run test:compliance:us2
+pnpm --filter @gh-reusable/dagger-pipelines run test:compliance:us3
+pnpm --filter @gh-reusable/dagger-pipelines run test:compliance
+```
+
+## Traceability
+
+- Plan: `specs/002-reusable-rust-pipeline/plan.md`
+- Research decisions: `specs/002-reusable-rust-pipeline/research.md`
+- Data entities/modes: `specs/002-reusable-rust-pipeline/data-model.md`
+- Contract rules: `specs/002-reusable-rust-pipeline/contracts/reusable-rust-pipeline-contract.md`

--- a/specs/002-reusable-rust-pipeline/research.md
+++ b/specs/002-reusable-rust-pipeline/research.md
@@ -1,0 +1,41 @@
+# Phase 0 Research: Reusable Rust Pipeline Architecture
+
+## Decision 1: Reusable contract shape and compatibility mode
+
+- **Decision**: Introduce the new Rust pipeline as an additive reusable contract, preserving existing `rust-build-n-test` and `publish` behavior as compatibility surfaces.
+- **Rationale**: Existing downstream consumers should not be forced into immediate migration or altered default behavior.
+- **Alternatives considered**:
+  - Replace existing Rust workflows directly (higher breakage risk).
+  - Keep separate docs/publish workflows with no unified contract (continues fragmentation).
+
+## Decision 2: Publish gating and secret requirement
+
+- **Decision**: Keep publish explicitly opt-in and fail fast on missing `CARGO_REGISTRY_TOKEN` when publish mode is enabled.
+- **Rationale**: This enforces FR-005/FR-006 safety guarantees and avoids ambiguous publish-time failures.
+- **Alternatives considered**:
+  - Implicit publish when token is present (accidental release risk).
+  - Late validation during `cargo publish` (slower, less actionable errors).
+
+## Decision 3: Docs publication path
+
+- **Decision**: Add an explicit docs publish intent and wire docs deployment through shared reusable behavior with mode-specific permissions.
+- **Rationale**: Repository currently has no reusable GitHub Pages docs publish workflow; explicit opt-in keeps default CI non-mutating.
+- **Alternatives considered**:
+  - Always generate/publish docs during baseline Rust CI (unnecessary permissions and runtime cost).
+  - Repository-specific ad hoc docs shell steps in workflow YAML (violates thin-workflow goal).
+
+## Decision 4: Dagger contract extension strategy
+
+- **Decision**: Keep workflows thin and evolve Dagger `@func()` contracts in `packages/dagger-module/src/index.ts` for Rust baseline + optional publish/docs behavior.
+- **Rationale**: This aligns with repository architecture and existing governance tests that enforce call-name contract integrity.
+- **Alternatives considered**:
+  - Implement mode logic in workflow YAML conditionals (contract drift risk).
+  - Introduce wrapper scripts outside Dagger module (extra maintenance surface).
+
+## Decision 5: Governance and validation strategy
+
+- **Decision**: Validate via focused `@gh-reusable/dagger-pipelines` suites plus workspace-wide `pnpm` checks.
+- **Rationale**: Focused suites provide fast contract regression detection; workspace checks ensure cross-package safety.
+- **Alternatives considered**:
+  - Full workspace checks only (slower iteration).
+  - Narrow Rust-only tests with no governance coverage (misses contract drift).

--- a/specs/002-reusable-rust-pipeline/spec.md
+++ b/specs/002-reusable-rust-pipeline/spec.md
@@ -1,0 +1,182 @@
+# Feature Specification: Reusable Rust Pipeline Architecture
+
+## Summary
+
+Introduce a new reusable Rust pipeline contract for downstream repositories that centralizes build/test execution, optional crates.io publishing, and optional Rust docs publication to GitHub Pages through shared pipeline code.
+
+## Motivation and Problem Statement
+
+Rust support exists today, but build/test, publishing, and docs publishing are not yet unified under one reusable contract with explicit gating and secret requirements. This creates duplication risk and makes downstream adoption less predictable.
+
+This feature ensures Rust consumers get one clear reusable interface with explicit inputs/secrets, safe publish behavior, and compatibility with existing Rust workflow entrypoints already used in this repository.
+
+## Scope
+
+### In scope
+
+- Define a new reusable Rust pipeline contract that supports build + test by default.
+- Add optional crates.io publishing behavior guarded by explicit publish intent.
+- Enforce crates token requirements when publish intent is enabled.
+- Add optional Rust docs publication path to GitHub Pages using shared pipeline behavior.
+- Define least-privilege permissions and required/optional secrets for each execution mode.
+- Define compatibility expectations with existing `rust-build-n-test` and publish workflow usage patterns.
+
+### Out of scope
+
+- Replacing non-Rust language pipeline contracts.
+- Changing crate versioning policy or release governance outside pipeline execution behavior.
+- Introducing new package registry targets beyond crates.io in this iteration.
+
+## Affected Contracts
+
+- Reusable workflow contract:
+  - New reusable Rust pipeline entrypoint with explicit inputs: `toolchain`, `components`, `target`, `name`, `publish`, `registry`, `version`, `publish_docs`, `docs_path`, and `runs-on`.
+  - Explicit secrets contract distinguishing always-required vs conditionally-required secrets: `DAGGER_CLOUD_TOKEN` (optional), `CARGO_REGISTRY_TOKEN` (conditionally required when `publish: true`).
+- Dagger module `@func()` contracts:
+  - Public function names and call names remain explicit, stable, and aligned to kebab-case naming conventions used by workflow callers (`rust-build-and-test`, `publish-rust-crate`, and docs-publish entrypoint when added).
+  - Thin workflow adapters continue delegating core behavior through `.github/actions/dagger-run`.
+- Downstream compatibility expectations:
+  - Existing `rust-build-n-test` and publish workflow consumers must remain compatible via adapter or equivalent contract continuity.
+  - Migration path must avoid forced breaking changes for consumers that only need build/test.
+
+## Runtime and Defaults Impact
+
+- Rust pipeline execution must align with repository runtime defaults and shared reusable workflow expectations.
+- Publish and docs paths must remain opt-in, so default Rust CI behavior remains build/test focused.
+- Any additional runtime assumptions for docs generation/publication must be documented in the reusable contract.
+
+## Security and Permissions Impact
+
+- Pipeline must use least-privilege permissions by default for build/test-only runs.
+- Publishing and docs publication modes must elevate permissions only when their corresponding option is enabled.
+- Crates publishing must require a crates token only when publish is enabled, and must fail safely before release mutation when missing.
+- Secret usage must be explicit in the reusable workflow contract so downstream repositories know exactly what to provide.
+
+## Risks and Mitigations
+
+- **Risk**: Downstream repos accidentally trigger publish behavior.  
+  **Mitigation**: Publish is opt-in and disabled by default with explicit input gating.
+- **Risk**: Missing `CARGO_REGISTRY_TOKEN` causes ambiguous failures.  
+  **Mitigation**: Validate token presence up front when publish is enabled and return a clear failure reason.
+- **Risk**: Docs publication introduces broader permissions than needed.  
+  **Mitigation**: Scope docs permissions to docs-enabled runs only and keep build/test permissions minimal.
+- **Risk**: Existing Rust workflow consumers regress during migration.  
+  **Mitigation**: Preserve compatibility expectations and validate with current `rust-build-n-test` and publish usage patterns.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Run reusable Rust CI baseline (Priority: P1)
+
+As a downstream repository maintainer, I want a shared Rust pipeline that always runs build and test so I can adopt repository-standard Rust CI behavior without custom pipeline logic.
+
+**Why this priority**: Build/test is the baseline path every Rust consumer needs, and it establishes the reusable contract foundation.
+
+**Independent Test**: Invoke the reusable pipeline with default options and confirm build/test completes with no publish or docs mutation behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a downstream repo uses the reusable Rust pipeline with default inputs, **When** the workflow runs, **Then** build and test execute successfully and no publish step is attempted.
+2. **Given** build or test fails, **When** the reusable pipeline completes, **Then** the workflow reports failure and no publish or docs publication is performed.
+
+---
+
+### User Story 2 - Publish crate safely when requested (Priority: P1)
+
+As a release maintainer, I want crates.io publish to run only when explicitly enabled and properly authenticated so releases are intentional and secure.
+
+**Why this priority**: Publishing is high-impact and must be strictly gated to prevent accidental or unsafe releases.
+
+**Independent Test**: Run one invocation with publish enabled and valid token, and one invocation with publish enabled but token omitted; verify gated behavior in both.
+
+**Acceptance Scenarios**:
+
+1. **Given** publish is enabled and crates token is provided, **When** pipeline checks pass, **Then** the crate publish path runs.
+2. **Given** publish is enabled and crates token is missing, **When** the workflow starts publish validation, **Then** it fails with a clear contract error before any publish action.
+3. **Given** publish is disabled, **When** the workflow runs, **Then** crates token is not required and no publish action is attempted.
+
+---
+
+### User Story 3 - Publish Rust docs to GitHub Pages via shared path (Priority: P2)
+
+As a documentation owner, I want optional Rust docs publication through shared reusable behavior so docs deployment is consistent across repositories.
+
+**Why this priority**: Docs publication is valuable but secondary to core CI and release safety.
+
+**Independent Test**: Enable docs publication in a pipeline run and verify docs are generated and published through the shared publication path after successful checks.
+
+**Acceptance Scenarios**:
+
+1. **Given** docs publish is enabled and prerequisites are satisfied, **When** the workflow completes build/test successfully, **Then** generated Rust docs are published to GitHub Pages through shared pipeline behavior.
+2. **Given** docs publish is disabled, **When** the workflow runs, **Then** no docs publication is attempted.
+
+### Edge Cases
+
+- Publish enabled with empty or invalid crates token input.
+- Publish enabled while build/test fails earlier in the run.
+- Docs publish enabled but docs generation output is empty or invalid.
+- Build/test-only consumers that pass no publish/docs inputs.
+- Existing `rust-build-n-test` and publish consumers that rely on prior call contracts.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The repository MUST provide one new reusable Rust pipeline contract consumable by downstream repositories.
+- **FR-002**: The reusable Rust pipeline MUST execute build + test as the default behavior.
+- **FR-003**: The reusable Rust pipeline MUST expose an explicit publish enablement input that defaults to disabled.
+- **FR-004**: The reusable Rust pipeline MUST expose an explicit docs publication enablement input that defaults to disabled.
+- **FR-005**: When publish enablement is true, the pipeline MUST require `CARGO_REGISTRY_TOKEN` before attempting any publish action.
+- **FR-006**: When publish enablement is true and crates token is missing, the pipeline MUST fail with a clear contract validation error before mutating release state.
+- **FR-007**: When publish enablement is false, the crates token MUST be treated as optional and no crates publish action may run.
+- **FR-008**: When docs publication is enabled, generated Rust docs MUST be published to GitHub Pages via shared reusable pipeline behavior.
+- **FR-009**: Docs publication MUST only run after successful required preconditions for that run, including successful baseline build/test.
+- **FR-010**: Workflow inputs and secrets MUST be explicitly documented as required, optional, and conditionally-required.
+- **FR-011**: Workflow permissions MUST follow least-privilege defaults, with any elevated scopes limited to publish-enabled or docs-enabled runs.
+- **FR-012**: The design MUST preserve compatibility expectations with existing `rust-build-n-test` and publish workflow contracts through non-breaking consumer behavior or documented adapters.
+- **FR-013**: Reusable workflow call naming and public Dagger function naming MUST remain explicit and aligned with kebab-case `@func` call conventions.
+
+### Key Entities
+
+- **Rust Pipeline Invocation**: A single execution request of the reusable Rust workflow with explicit inputs, secrets, and mode flags.
+- **Publish Intent**: The explicit workflow input that determines whether crates publishing is permitted in that run.
+- **Docs Publish Intent**: The explicit workflow input that determines whether Rust docs are published to GitHub Pages in that run.
+- **Conditional Secret Requirement**: A contract rule that marks a secret as mandatory only when a specific optional capability is enabled.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of default Rust pipeline runs execute build/test without requiring publish or docs secrets.
+- **SC-002**: 100% of runs with publish enabled and missing crates token fail before any publish mutation.
+- **SC-003**: 100% of runs with publish disabled skip crates publication regardless of token presence.
+- **SC-004**: At least 95% of downstream Rust consumers can adopt the new reusable contract without changing their core build/test intent.
+- **SC-005**: 100% of docs-enabled successful runs produce a completed docs publication outcome to GitHub Pages or a clear, actionable failure reason.
+
+## Assumptions
+
+- Downstream consumers using Rust pipelines already rely on reusable workflow-based integration patterns.
+- Existing Rust workflows in this repository represent the baseline compatibility target for migration.
+- Publishing to crates.io is a controlled release operation and should remain opt-in.
+- GitHub Pages publication for Rust docs is allowed only when explicitly enabled by repository owners.
+
+## Validation Plan
+
+- Validate contract-level behavior for each mode:
+  - build/test only,
+  - build/test + publish enabled,
+  - build/test + docs publish enabled,
+  - build/test + both optional modes enabled.
+- Validate publish gating scenarios:
+  - publish enabled with valid token,
+  - publish enabled with missing token,
+  - publish disabled with and without token.
+- Validate least-privilege permissions for default, publish-enabled, and docs-enabled runs.
+- Validate compatibility by exercising existing `rust-build-n-test` and publish workflow usage expectations against the new reusable contract path.
+- Validate that workflow adapters remain thin and delegate core behavior through shared Dagger module contracts.
+
+## Rollout and Rollback
+
+- Roll out the reusable Rust pipeline as an additive contract and migrate current Rust workflow entrypoints in controlled phases.
+- Keep compatibility adapters for existing `rust-build-n-test` and publish integration expectations during migration.
+- If regressions are found, roll back by reverting consumers to the prior known-good reusable workflow reference and disabling optional publish/docs flags in affected repos.
+- Resume rollout only after validation confirms contract compatibility and publish/docs gating behavior is restored.

--- a/specs/002-reusable-rust-pipeline/tasks.md
+++ b/specs/002-reusable-rust-pipeline/tasks.md
@@ -1,0 +1,203 @@
+# Tasks: Reusable Rust Pipeline Architecture
+
+**Input**: Design documents from `/specs/002-reusable-rust-pipeline/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+## Execution Rules
+
+- Keep workflow YAML thin; implement mode logic in Dagger `@func()` contracts.
+- Pair every workflow/module contract change with governance tests in the same PR.
+- Preserve compatibility for existing `rust-build-n-test` and `publish` (`target: rust-crate`) consumers.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish feature tracking artifacts and validation logs.
+
+- [x] T001 Create Rust pipeline contract matrix in specs/002-reusable-rust-pipeline/checklists/contract-matrix.md
+- [x] T002 Create feature validation evidence log in specs/002-reusable-rust-pipeline/checklists/validation-log.md
+- [x] T003 [P] Create docs publish prerequisites checklist in specs/002-reusable-rust-pipeline/checklists/docs-pages-prereqs.md
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared primitives for mode-aware contract validation/reporting.
+
+**⚠️ CRITICAL**: No user story work starts until this phase is complete.
+
+- [x] T004 Add reusable conditional input/secret assertion helpers in packages/dagger-pipelines/src/workflows.ts
+- [x] T005 [P] Extend pipeline report structures for rust mode outcomes in packages/dagger-module/src/types.ts
+- [x] T006 [P] Add mode-aware reporting helpers for publish/docs decisions in packages/dagger-module/src/reporting.ts
+- [x] T007 Wire shared workflow utilities exports for updated governance tests in packages/dagger-pipelines/src/index.ts
+
+**Checkpoint**: Shared validation and reporting primitives are ready for all stories.
+
+---
+
+## Phase 3: User Story 1 - Run reusable Rust CI baseline (Priority: P1) 🎯 MVP
+
+**Goal**: Deliver a reusable Rust contract that always runs build/test by default.
+
+**Independent Test**: Invoke Rust reusable workflow with defaults and confirm only build/test paths run.
+
+### Tests for User Story 1
+
+- [x] T008 [P] [US1] Add baseline Rust contract input/secret reference assertions in packages/dagger-pipelines/src/workflow-governance.test.ts
+- [x] T009 [P] [US1] Add Rust baseline `@func()` call-name alignment checks in packages/dagger-pipelines/src/dagger-module-integration.test.ts
+- [x] T010 [P] [US1] Add Rust reusable defaults/permission assertions in packages/dagger-pipelines/src/standards-defaults.test.ts
+
+### Implementation for User Story 1
+
+- [x] T011 [US1] Add unified Rust reusable contract inputs/defaults in .github/workflows/rust-build-n-test.yaml
+- [x] T012 [US1] Implement baseline reusable Rust pipeline `@func()` orchestration in packages/dagger-module/src/index.ts
+- [x] T013 [P] [US1] Update Rust parity workflow to validate baseline reusable contract path in .github/workflows/test-rust-build-n-test.yaml
+- [x] T014 [US1] Document baseline invocation and compatibility notes in specs/002-reusable-rust-pipeline/contracts/reusable-rust-pipeline-contract.md
+
+**Checkpoint**: US1 is independently testable with default build/test behavior.
+
+---
+
+## Phase 4: User Story 2 - Publish crate safely when requested (Priority: P1)
+
+**Goal**: Gate publish execution behind explicit intent and required crates token.
+
+**Independent Test**: Run publish-enabled scenario with and without `CARGO_REGISTRY_TOKEN` and verify fail-fast gating behavior.
+
+### Tests for User Story 2
+
+- [x] T015 [P] [US2] Add publish gate assertions for `publish` input and rust token handling in packages/dagger-pipelines/src/publish-workflow.test.ts
+- [x] T016 [P] [US2] Add release compatibility assertions for rust publish adapter behavior in packages/dagger-pipelines/src/release-workflows.test.ts
+- [x] T017 [P] [US2] Add mode-specific permission assertions for publish-enabled Rust runs in packages/dagger-pipelines/src/security-workflows.test.ts
+
+### Implementation for User Story 2
+
+- [x] T018 [US2] Enforce fail-fast required CARGO_REGISTRY_TOKEN validation when publish is enabled in packages/dagger-module/src/index.ts
+- [x] T019 [US2] Add publish opt-in contract wiring for Rust reusable workflow in .github/workflows/rust-build-n-test.yaml
+- [x] T020 [US2] Preserve `target: rust-crate` compatibility while delegating through updated publish path in .github/workflows/publish.yaml
+- [x] T021 [US2] Add publish-gating decision details to pipeline summaries in packages/dagger-module/src/reporting.ts
+
+**Checkpoint**: US2 blocks accidental publish and enforces required token contract.
+
+---
+
+## Phase 5: User Story 3 - Publish Rust docs to GitHub Pages via shared path (Priority: P2)
+
+**Goal**: Provide optional docs publication to GitHub Pages through shared reusable behavior.
+
+**Independent Test**: Enable docs mode and verify docs generation + GitHub Pages publication only after successful baseline checks.
+
+### Tests for User Story 3
+
+- [x] T022 [P] [US3] Add docs-mode input/secret reference coverage in packages/dagger-pipelines/src/workflow-governance.test.ts
+- [x] T023 [P] [US3] Add docs publication compatibility assertions, including actionable failure-path messaging checks, in packages/dagger-pipelines/src/release-workflows.test.ts
+- [x] T024 [P] [US3] Add docs publish `@func()` call-name integration coverage in packages/dagger-pipelines/src/dagger-module-integration.test.ts
+
+### Implementation for User Story 3
+
+- [x] T025 [US3] Implement shared Rust docs generation/publication pipeline contract in packages/dagger-module/src/index.ts
+- [x] T026 [US3] Add docs publish opt-in and Pages permission gating in .github/workflows/rust-build-n-test.yaml
+- [x] T027 [US3] Add reusable docs publication adapter workflow in .github/workflows/rust-docs-publish.yaml
+- [x] T028 [US3] Add docs-mode parity coverage in .github/workflows/test-rust-build-n-test.yaml
+- [x] T029 [US3] Document docs publication prerequisites and rollback notes in specs/002-reusable-rust-pipeline/quickstart.md
+
+**Checkpoint**: US3 enables optional GitHub Pages docs publication without changing default CI behavior.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency, command validation, and rollout readiness.
+
+- [x] T030 [P] Reconcile final contract/design notes with implemented behavior in specs/002-reusable-rust-pipeline/plan.md
+- [x] T031 [P] Add/update focused compliance aliases for Rust stories in packages/dagger-pipelines/package.json
+- [x] T032 Run focused validation commands and record evidence in specs/002-reusable-rust-pipeline/checklists/validation-log.md
+- [x] T033 Run workspace validation commands and record final pass/fail status in specs/002-reusable-rust-pipeline/checklists/validation-log.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies.
+- **Phase 2 (Foundational)**: Depends on Phase 1; blocks all user stories.
+- **Phase 3 (US1)**: Depends on Phase 2; MVP.
+- **Phase 4 (US2)**: Depends on Phase 2 and US1 contract wiring.
+- **Phase 5 (US3)**: Depends on Phase 2 and US1 baseline contract.
+- **Phase 6 (Polish)**: Depends on completion of targeted user stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after foundational work; no story dependency.
+- **US2 (P1)**: Starts after US1 baseline contract is in place.
+- **US3 (P2)**: Starts after US1 baseline contract; independent of US2 publish internals.
+
+### Within Each User Story
+
+- Write/expand tests first and confirm they fail for missing behavior.
+- Implement Dagger module contract logic before workflow adapter rewiring.
+- Finish documentation updates after behavior and tests pass.
+
+---
+
+## Parallel Opportunities
+
+- Setup: T003 can run with T001-T002.
+- Foundational: T005-T006 can run in parallel after T004.
+- US1 tests: T008-T010 can run in parallel.
+- US2 tests: T015-T017 can run in parallel.
+- US3 tests: T022-T024 can run in parallel.
+- Polish: T030-T031 can run in parallel before T032-T033.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "T008 [US1] Add baseline contract assertions in packages/dagger-pipelines/src/workflow-governance.test.ts"
+Task: "T009 [US1] Add Rust call-name alignment checks in packages/dagger-pipelines/src/dagger-module-integration.test.ts"
+Task: "T010 [US1] Add defaults/permission assertions in packages/dagger-pipelines/src/standards-defaults.test.ts"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "T015 [US2] Add publish gate assertions in packages/dagger-pipelines/src/publish-workflow.test.ts"
+Task: "T016 [US2] Add release compatibility assertions in packages/dagger-pipelines/src/release-workflows.test.ts"
+Task: "T017 [US2] Add publish permission assertions in packages/dagger-pipelines/src/security-workflows.test.ts"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "T022 [US3] Add docs-mode governance assertions in packages/dagger-pipelines/src/workflow-governance.test.ts"
+Task: "T023 [US3] Add docs compatibility assertions in packages/dagger-pipelines/src/release-workflows.test.ts"
+Task: "T024 [US3] Add docs call-name integration assertions in packages/dagger-pipelines/src/dagger-module-integration.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Deliver US1 tests + implementation (T008-T014).
+3. Validate baseline behavior with focused governance suites before expanding modes.
+
+### Incremental Delivery
+
+1. Ship MVP baseline reusable Rust contract (US1).
+2. Add publish gating and token requirements (US2).
+3. Add optional docs publication to GitHub Pages via shared path (US3).
+4. Complete polish and full validation evidence capture (Phase 6).
+
+### Final Validation Commands
+
+- `pnpm --filter @gh-reusable/dagger-pipelines run test -- src/workflow-governance.test.ts`
+- `pnpm --filter @gh-reusable/dagger-pipelines run test -- src/dagger-module-integration.test.ts`
+- `pnpm --filter @gh-reusable/dagger-pipelines run test -- src/publish-workflow.test.ts src/release-workflows.test.ts`
+- `pnpm --filter @gh-reusable/dagger-pipelines run test -- src/standards-defaults.test.ts src/security-workflows.test.ts src/audit-workflow.test.ts`
+- `pnpm run typecheck`
+- `pnpm run test`


### PR DESCRIPTION
- implement 002 spec end-to-end with a unified `rust-pipeline` Dagger contract
- add `rust-docs-build` and shared reusable `rust-docs-publish.yaml` workflow
- extend `rust-build-n-test.yaml` with opt-in publish/docs inputs and conditional token wiring
- preserve publish compatibility (`target: rust-crate`) while adding docs deployment path
- add governance coverage for rust workflow contracts, security/permissions, and call-name alignment
- add 002 checklists and validation logs with focused and workspace command results
- regenerate CI skill artifacts so manifest/skill docs include new rust workflow and functions
- Rust pipelines :)
